### PR TITLE
正确处理不含文字只含符号的文本的TTS及后续流程

### DIFF
--- a/src/main/java/com/xiaozhi/websocket/service/AudioService.java
+++ b/src/main/java/com/xiaozhi/websocket/service/AudioService.java
@@ -1,6 +1,7 @@
 package com.xiaozhi.websocket.service;
 
 import com.xiaozhi.utils.OpusProcessor;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -196,12 +197,14 @@ public class AudioService {
      * @return 处理结果，包含opus数据和持续时间
      */
     public AudioProcessResult processAudioFile(String audioFilePath, int sampleRate, int channels) {
+        AudioProcessResult emptyAudioProcessResult = new AudioProcessResult();
+        if (StringUtils.isEmpty(audioFilePath)) { return emptyAudioProcessResult; }
         try {
             // 从音频文件获取PCM数据
             byte[] pcmData = extractPcmFromAudio(audioFilePath);
             if (pcmData == null) {
                 logger.error("无法从文件提取PCM数据: {}", audioFilePath);
-                return new AudioProcessResult();
+                return emptyAudioProcessResult;
             }
 
             // 计算音频时长
@@ -213,7 +216,7 @@ public class AudioService {
             return new AudioProcessResult(opusFrames, durationMs);
         } catch (Exception e) {
             logger.error("处理音频文件失败: {}", audioFilePath, e);
-            return new AudioProcessResult();
+            return emptyAudioProcessResult;
         }
     }
 

--- a/src/main/java/com/xiaozhi/websocket/tts/providers/VolcengineTtsService.java
+++ b/src/main/java/com/xiaozhi/websocket/tts/providers/VolcengineTtsService.java
@@ -68,6 +68,11 @@ public class VolcengineTtsService implements TtsService {
             logger.warn("文本内容为空！");
             return null;
         }
+		
+        if (!containsLetter(text)) {
+            logger.warn("文本不包含文字！\"{}\"", text);
+            return "";
+        }
 
         try {
             // 生成音频文件名
@@ -86,6 +91,17 @@ public class VolcengineTtsService implements TtsService {
             logger.error("语音合成时发生错误！", e);
             throw e;
         }
+    }
+	
+    public static boolean containsLetter(String s) {
+        for (int i = 0; i < s.length(); ) {
+            int codepoint = s.codePointAt(i);
+            if (Character.isIdeographic(codepoint) || Character.isLetter(codepoint)) {
+                return true;
+            }
+            i += Character.charCount(codepoint);
+        }
+        return false;
     }
 
     /**
@@ -143,7 +159,7 @@ public class VolcengineTtsService implements TtsService {
             try (Response response = client.newCall(request).execute()) {
                 if (!response.isSuccessful()) {
                     String errorBody = response.body() != null ? response.body().string() : "无响应体";
-                    logger.error("TTS请求失败: {} {}, 错误信息: {}", response.code(), response.message(), errorBody);
+                    logger.error("TTS请求失败: text: {}, code: {}, response: {}, 错误信息: {}", text, response.code(), response.message(), errorBody);
                     return false;
                 }
 


### PR DESCRIPTION
语句切分导致某些子句子只包含符号不包含文字，TTS报错，textToSpeech方法会抛出异常，且如果该子句是对话响应切分后的最后一个，会导致结束消息不被发送（因为结束消息是在audioService.sendAudioMessage方法中处理到最后一条消息的时候被加入消息队列的），后续处理中断，客户端无法恢复语音输入。可以将textToSpeech在这种情况下的返回值设为长度为0的字符串("")。（不能用null，原因是Mono会忽略掉null）