### PR TITLE
使用netty重构websocket优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 target/
+usr/
 node_modules/
 audio/*.mp3
 audio/*.vtt
 vosk*
+*.zip
+*.log
+*.js

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@ vosk*
 *.zip
 *.log
 *.js
+
+# IntelliJ IDEA
+.idea/
+*.iml
+*.ipr
+*.iws
+out/
+gen/

--- a/pom.xml
+++ b/pom.xml
@@ -82,17 +82,31 @@
             <artifactId>concentus</artifactId>
             <version>1.0.2</version>
         </dependency>
-        <!-- 音频操作 -->
+        <!--javacv 音频操作-->
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>javacv</artifactId>
             <version>1.5.9</version>
+            <exclusions>
+                <!-- 只排除明确不需要的模块 -->
+                <exclusion>
+                    <groupId>org.bytedeco</groupId>
+                    <artifactId>opencv</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bytedeco</groupId>
+                    <artifactId>flycapture</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>ffmpeg</artifactId>
             <version>6.0-1.5.9</version>
+            <classifier>windows-x86_64</classifier>
+<!--            <classifier>linux-x86_64</classifier>-->
         </dependency>
+        <!---->
         <!-- Vosk -->
         <dependency>
             <groupId>com.alphacephei</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
             <artifactId>hutool-all</artifactId>
             <version>5.8.20</version>
         </dependency>
+        <!-- lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
             <artifactId>kotlin-stdlib</artifactId>
             <version>1.4.10</version>
         </dependency>
+        <!-- hutool-all -->
+        <dependency>
+            <groupId>cn.hutool</groupId>
+            <artifactId>hutool-all</artifactId>
+            <version>5.8.20</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -120,13 +120,13 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>5.0.0-alpha.14</version>
+            <version>4.9.3</version>
         </dependency>
         <!-- Kotlin 运行时 -->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.9.0</version> <!-- 使用与OkHttp 5.0.0-alpha.14兼容的版本 -->
+            <version>1.4.10</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/xiaozhi/XiaozhiApplication.java
+++ b/src/main/java/com/xiaozhi/XiaozhiApplication.java
@@ -17,7 +17,7 @@ public class XiaozhiApplication {
 
     Logger logger = LoggerFactory.getLogger(XiaozhiApplication.class);
 
-    @Value("${netty.websocket.port:8091}")
+    @Value("${netty.websocket.port:8082}")
     private int nettyPort;
 
     public static void main(String[] args) {

--- a/src/main/java/com/xiaozhi/common/config/ThreadPoolConfig.java
+++ b/src/main/java/com/xiaozhi/common/config/ThreadPoolConfig.java
@@ -1,0 +1,42 @@
+package com.xiaozhi.common.config;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Configuration
+public class ThreadPoolConfig {
+
+    @Bean(name = "baseThreadPool")
+    public ExecutorService baseThreadPool() {
+        return new ThreadPoolExecutor(
+                10, // 核心线程数
+                20, // 最大线程数
+                60L, // 空闲线程存活时间
+                TimeUnit.SECONDS, // 时间单位
+                new LinkedBlockingQueue<>(100), // 任务队列
+                new CustomThreadFactory("base-pool"), // 自定义线程工厂
+                new ThreadPoolExecutor.CallerRunsPolicy() // 拒绝策略
+        );
+    }
+
+    // 自定义线程工厂
+    private static class CustomThreadFactory implements ThreadFactory {
+        private final String namePrefix;
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+        public CustomThreadFactory(String namePrefix) {
+            this.namePrefix = namePrefix;
+        }
+
+        @Override
+        public Thread newThread(@NotNull Runnable r) {
+            Thread t = new Thread(r, namePrefix + "-" + threadNumber.getAndIncrement());
+            t.setDaemon(false); // 设置为非守护线程
+            return t;
+        }
+    }
+}

--- a/src/main/java/com/xiaozhi/common/config/ThreadPoolConfig.java
+++ b/src/main/java/com/xiaozhi/common/config/ThreadPoolConfig.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Configuration
 public class ThreadPoolConfig {
 
+    // 基础通用线程池
     @Bean(name = "baseThreadPool")
     public ExecutorService baseThreadPool() {
         return new ThreadPoolExecutor(
@@ -23,19 +24,59 @@ public class ThreadPoolConfig {
         );
     }
 
-    // 自定义线程工厂
+    // 音频服务专用线程池（新增）
+    @Bean(name = "audioScheduledExecutor")
+    public ScheduledExecutorService audioScheduledExecutor() {
+        return new ScheduledThreadPoolExecutor(
+                Runtime.getRuntime().availableProcessors(),
+                new CustomThreadFactory("audio-sender", true), // 设置为守护线程
+                new ThreadPoolExecutor.DiscardOldestPolicy() // 更适合音频场景的拒绝策略
+        );
+    }
+
+    // 音频清理专用线程池（新增）
+    @Bean(name = "audioCleanupExecutor")
+    public ExecutorService audioCleanupExecutor() {
+        return new ThreadPoolExecutor(
+                1, // 单线程处理清理任务
+                1,
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(50),
+                new CustomThreadFactory("audio-cleanup", true), // 守护线程
+                new ThreadPoolExecutor.DiscardPolicy() // 清理任务可丢弃
+        );
+    }
+
+    // 增强版自定义线程工厂
     private static class CustomThreadFactory implements ThreadFactory {
         private final String namePrefix;
+        private final boolean daemon;
         private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private static final SecurityManager SECURITY_MANAGER = System.getSecurityManager();
 
         public CustomThreadFactory(String namePrefix) {
-            this.namePrefix = namePrefix;
+            this(namePrefix, false);
+        }
+
+        public CustomThreadFactory(String namePrefix, boolean daemon) {
+            this.namePrefix = namePrefix + "-";
+            this.daemon = daemon;
         }
 
         @Override
         public Thread newThread(@NotNull Runnable r) {
-            Thread t = new Thread(r, namePrefix + "-" + threadNumber.getAndIncrement());
-            t.setDaemon(false); // 设置为非守护线程
+            Thread t = new Thread(SECURITY_MANAGER == null ? 
+                    Thread.currentThread().getThreadGroup() : 
+                    SECURITY_MANAGER.getThreadGroup(),
+                    r,
+                    namePrefix + threadNumber.getAndIncrement(),
+                    0);
+            
+            t.setDaemon(daemon);
+            // 设置合理的默认优先级
+            if (t.getPriority() != Thread.NORM_PRIORITY) {
+                t.setPriority(Thread.NORM_PRIORITY);
+            }
             return t;
         }
     }

--- a/src/main/java/com/xiaozhi/mapper/DeviceMapper.xml
+++ b/src/main/java/com/xiaozhi/mapper/DeviceMapper.xml
@@ -51,7 +51,7 @@
         WHERE
             1 = 1
             <if test="deviceId != null and deviceId != ''">AND deviceId = #{deviceId}</if>
-            <if test="sessionId != null and sessionId != ''">AND sessionId = #{sessionId}</if>
+            <!--<if test="sessionId != null and sessionId != ''">AND sessionId = #{sessionId}</if>-->
             <if test="code != null and code != ''">AND code = #{code}</if>
             ORDER BY createTime DESC
         LIMIT 1

--- a/src/main/java/com/xiaozhi/mapper/RoleMapper.xml
+++ b/src/main/java/com/xiaozhi/mapper/RoleMapper.xml
@@ -31,7 +31,12 @@
             <if test="roleName != null and roleName != ''">roleName = #{roleName},</if>
             <if test="roleDesc != null and roleDesc != ''">roleDesc = #{roleDesc},</if>
             <if test="voiceName != null and voiceName != ''">voiceName = #{voiceName},</if>
-            <if test="ttsId != null and ttsId != ''">ttsId = #{ttsId},</if>
+            <if test="ttsId != null and ttsId != ''">
+                <choose>
+                    <when test="ttsId == -1">ttsId = null,</when>
+                    <otherwise>ttsId = #{ttsId},</otherwise>
+                </choose>
+            </if>
             <if test="state != null and state != ''">state = #{state},</if>
         </set>
         WHERE

--- a/src/main/java/com/xiaozhi/utils/AudioUtils.java
+++ b/src/main/java/com/xiaozhi/utils/AudioUtils.java
@@ -1,21 +1,27 @@
 package com.xiaozhi.utils;
 
+import org.bytedeco.ffmpeg.global.avcodec;
+import org.bytedeco.ffmpeg.global.avutil;
+import org.bytedeco.javacpp.Loader;
+import org.bytedeco.javacv.FFmpegFrameRecorder;
+import org.bytedeco.javacv.Frame;
+import org.bytedeco.javacv.FrameRecorder;
+import org.slf4j.Logger;
+
 import java.io.ByteArrayInputStream;
 import java.io.DataOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.UUID;
 
-import org.bytedeco.ffmpeg.global.avcodec;
-import org.bytedeco.ffmpeg.global.avutil;
-import org.bytedeco.javacv.FFmpegFrameRecorder;
-import org.bytedeco.javacv.Frame;
-import org.bytedeco.javacv.FrameRecorder;
-import org.slf4j.Logger;
-
 public class AudioUtils {
     public static final String AUDIO_PATH = "audio/";
     private static final Logger logger = org.slf4j.LoggerFactory.getLogger(AudioUtils.class);
+
+    // 添加静态初始化块加载本地库
+    static {
+        Loader.load(org.bytedeco.ffmpeg.global.avutil.class);
+    }
 
     /**
      * 将原始音频数据保存为MP3文件
@@ -31,9 +37,8 @@ public class AudioUtils {
         int sampleRate = 16000; // 采样率
         int channels = 1; // 单声道
 
-        try {
+        try(FFmpegFrameRecorder recorder = new FFmpegFrameRecorder(filePath, channels)) {
             // 创建内存中的帧记录器，直接输出到MP3文件
-            FFmpegFrameRecorder recorder = new FFmpegFrameRecorder(filePath, channels);
             recorder.setAudioChannels(channels);
             recorder.setSampleRate(sampleRate);
             recorder.setAudioCodec(avcodec.AV_CODEC_ID_MP3);
@@ -80,7 +85,7 @@ public class AudioUtils {
     /**
      * 将原始音频数据保存为WAV文件
      * 
-     * @param audio 音频数据
+     * @param audioData 音频数据
      * @return 文件名
      *
      */

--- a/src/main/java/com/xiaozhi/websocket/config/NettyWebSocketConfig.java
+++ b/src/main/java/com/xiaozhi/websocket/config/NettyWebSocketConfig.java
@@ -103,9 +103,15 @@ public class NettyWebSocketConfig {
                                             TimeUnit.SECONDS))
                                     // 心跳处理
                                     .addLast(new WebSocketHeartbeatHandler())
-                                    // WebSocket协议处理
-                                    .addLast(
-                                            new WebSocketServerProtocolHandler(websocketPath, null, true, maxFrameSize))
+                                    //处理 WebSocket 协议的升级和消息解析
+                                    .addLast(new WebSocketServerProtocolHandler(
+                                            websocketPath,
+                                            null,
+                                            true,
+                                            maxFrameSize,
+                                            false,  // 不检查起始帧
+                                            true    // 允许扩展
+                                    ))
                                     // WebSocket控制帧处理
                                     .addLast(new WebSocketControlFrameHandler())
                                     // WebSocket文本帧处理

--- a/src/main/java/com/xiaozhi/websocket/config/NettyWebSocketConfig.java
+++ b/src/main/java/com/xiaozhi/websocket/config/NettyWebSocketConfig.java
@@ -18,7 +18,6 @@ import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -51,21 +50,6 @@ public class NettyWebSocketConfig {
     @Value("${netty.websocket.idleTimeout:300}")
     private int idleTimeout;
 
-    @Autowired
-    private TextWebSocketFrameHandler textWebSocketFrameHandler;
-
-    @Autowired
-    private BinaryWebSocketFrameHandler binaryWebSocketFrameHandler;
-
-    @Autowired
-    private WebSocketControlFrameHandler webSocketControlFrameHandler;
-
-    @Autowired
-    private WebSocketExceptionHandler webSocketExceptionHandler;
-
-    @Autowired
-    private WebSocketHeartbeatHandler webSocketHeartbeatHandler;
-
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;
 
@@ -96,13 +80,6 @@ public class NettyWebSocketConfig {
                                     .addLast(new HttpObjectAggregator(maxFrameSize))
                                     // WebSocket握手处理
                                     .addLast(new WebSocketHandshakeHandler())
-                                    // WebSocket压缩支持
-                                    .addLast(new WebSocketServerCompressionHandler())
-                                    // 空闲连接检测
-                                    .addLast(new IdleStateHandler(idleTimeout, idleTimeout, idleTimeout,
-                                            TimeUnit.SECONDS))
-                                    // 心跳处理
-                                    .addLast(new WebSocketHeartbeatHandler())
                                     //处理 WebSocket 协议的升级和消息解析
                                     .addLast(new WebSocketServerProtocolHandler(
                                             websocketPath,
@@ -112,6 +89,13 @@ public class NettyWebSocketConfig {
                                             false,  // 不检查起始帧
                                             true    // 允许扩展
                                     ))
+                                    // WebSocket压缩支持
+                                    .addLast(new WebSocketServerCompressionHandler())
+                                    // 空闲连接检测
+                                    .addLast(new IdleStateHandler(idleTimeout, idleTimeout, idleTimeout,
+                                            TimeUnit.SECONDS))
+                                    // 心跳处理
+                                    .addLast(new WebSocketHeartbeatHandler())
                                     // WebSocket控制帧处理
                                     .addLast(new WebSocketControlFrameHandler())
                                     // WebSocket文本帧处理

--- a/src/main/java/com/xiaozhi/websocket/config/NettyWebSocketConfig.java
+++ b/src/main/java/com/xiaozhi/websocket/config/NettyWebSocketConfig.java
@@ -32,7 +32,7 @@ public class NettyWebSocketConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(NettyWebSocketConfig.class);
 
-    @Value("${netty.websocket.port:8091}")
+    @Value("${netty.websocket.port:8082}")
     private int port;
 
     @Value("${netty.websocket.path:/ws/xiaozhi/v1/}")

--- a/src/main/java/com/xiaozhi/websocket/config/NettyWebSocketConfig.java
+++ b/src/main/java/com/xiaozhi/websocket/config/NettyWebSocketConfig.java
@@ -50,6 +50,9 @@ public class NettyWebSocketConfig {
     @Value("${netty.websocket.idleTimeout:300}")
     private int idleTimeout;
 
+    @Value("${netty.websocket.writeIdleTimeout:120}")
+    private int writeIdleTimeout;
+
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;
 
@@ -92,14 +95,14 @@ public class NettyWebSocketConfig {
                                     // WebSocket压缩支持
                                     .addLast(new WebSocketServerCompressionHandler())
                                     // 空闲连接检测
-                                    .addLast(new IdleStateHandler(idleTimeout, idleTimeout, idleTimeout,
-                                            TimeUnit.SECONDS))
+                                    .addLast(new IdleStateHandler(idleTimeout, idleTimeout,
+                                            idleTimeout, TimeUnit.SECONDS))
                                     // 心跳处理
                                     .addLast(new WebSocketHeartbeatHandler())
-                                    // WebSocket控制帧处理
-                                    .addLast(new WebSocketControlFrameHandler())
                                     // WebSocket文本帧处理
                                     .addLast(new TextWebSocketFrameHandler())
+                                    // WebSocket控制帧处理
+                                    .addLast(new WebSocketControlFrameHandler())
                                     // WebSocket二进制帧处理
                                     .addLast(new BinaryWebSocketFrameHandler())
                                     // 异常处理（放在最后捕获所有未处理的异常）

--- a/src/main/java/com/xiaozhi/websocket/handler/BinaryWebSocketFrameHandler.java
+++ b/src/main/java/com/xiaozhi/websocket/handler/BinaryWebSocketFrameHandler.java
@@ -1,24 +1,19 @@
 package com.xiaozhi.websocket.handler;
 
+import cn.hutool.extra.spring.SpringUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xiaozhi.entity.SysConfig;
 import com.xiaozhi.entity.SysDevice;
 import com.xiaozhi.service.SysConfigService;
 import com.xiaozhi.websocket.llm.LlmManager;
-import com.xiaozhi.websocket.service.AudioService;
-import com.xiaozhi.websocket.service.MessageService;
-import com.xiaozhi.websocket.service.SpeechToTextService;
-import com.xiaozhi.websocket.service.TextToSpeechService;
-import com.xiaozhi.websocket.service.VadService;
-
+import com.xiaozhi.websocket.service.*;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -34,26 +29,19 @@ public class BinaryWebSocketFrameHandler extends SimpleChannelInboundHandler<Bin
 
   private static final Logger logger = LoggerFactory.getLogger(BinaryWebSocketFrameHandler.class);
 
-  @Autowired
-  private VadService vadService;
+  private final VadService vadService = SpringUtil.getBean(VadService.class);
 
-  @Autowired
-  private AudioService audioService;
+  private final AudioService audioService = SpringUtil.getBean(AudioService.class);
 
-  @Autowired
-  private MessageService messageService;
+  private final LlmManager llmManager = SpringUtil.getBean(LlmManager.class);
 
-  @Autowired
-  private SpeechToTextService speechToTextService;
+  private final MessageService messageService = SpringUtil.getBean(MessageService.class);
 
-  @Autowired
-  private TextToSpeechService textToSpeechService;
+  private final TextToSpeechService textToSpeechService = SpringUtil.getBean(TextToSpeechService.class);
 
-  @Autowired
-  private LlmManager llmManager;
+  private final SpeechToTextService speechToTextService = SpringUtil.getBean(SpeechToTextService.class);
 
-  @Autowired
-  private SysConfigService configService;
+  private final SysConfigService configService = SpringUtil.getBean(SysConfigService.class);
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -94,8 +82,6 @@ public class BinaryWebSocketFrameHandler extends SimpleChannelInboundHandler<Bin
     } catch (Exception e) {
       logger.error("处理二进制消息失败", e);
     }
-    // 继续处理请求
-    ctx.fireChannelRead(frame);
   }
 
   /**

--- a/src/main/java/com/xiaozhi/websocket/handler/BinaryWebSocketFrameHandler.java
+++ b/src/main/java/com/xiaozhi/websocket/handler/BinaryWebSocketFrameHandler.java
@@ -94,6 +94,8 @@ public class BinaryWebSocketFrameHandler extends SimpleChannelInboundHandler<Bin
     } catch (Exception e) {
       logger.error("处理二进制消息失败", e);
     }
+    // 继续处理请求
+    ctx.fireChannelRead(frame);
   }
 
   /**

--- a/src/main/java/com/xiaozhi/websocket/handler/TextWebSocketFrameHandler.java
+++ b/src/main/java/com/xiaozhi/websocket/handler/TextWebSocketFrameHandler.java
@@ -247,7 +247,10 @@ public class TextWebSocketFrameHandler extends SimpleChannelInboundHandler<TextW
     // 使用句子切分处理流式响应
     llmManager.chatStreamBySentence(device, text, (sentence, isStart, isEnd) -> {
       try {
+        // 1. 文本转语音
         String audioPath = textToSpeechService.textToSpeech(sentence, null, device.getVoiceName());
+
+        // 2. 发送音频
         audioService.sendAudio(ctx.channel(), audioPath, sentence, isStart, isEnd);
       } catch (Exception e) {
         logger.error("处理句子失败: {}", e.getMessage(), e);

--- a/src/main/java/com/xiaozhi/websocket/handler/TextWebSocketFrameHandler.java
+++ b/src/main/java/com/xiaozhi/websocket/handler/TextWebSocketFrameHandler.java
@@ -13,6 +13,7 @@ import com.xiaozhi.websocket.service.TextToSpeechService;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -107,10 +108,8 @@ public class TextWebSocketFrameHandler extends SimpleChannelInboundHandler<TextW
       }
     } catch (Exception e) {
       logger.error("处理消息失败", e);
+      ReferenceCountUtil.release(frame);
     }
-
-    // 继续处理请求
-    ctx.fireChannelRead(frame);
   }
 
   /**

--- a/src/main/java/com/xiaozhi/websocket/handler/TextWebSocketFrameHandler.java
+++ b/src/main/java/com/xiaozhi/websocket/handler/TextWebSocketFrameHandler.java
@@ -251,6 +251,7 @@ public class TextWebSocketFrameHandler extends SimpleChannelInboundHandler<TextW
         String audioPath = textToSpeechService.textToSpeech(sentence, null, device.getVoiceName());
 
         // 2. 发送音频
+        logger.info("发送音频,sentence={},isStart={},isEnd={}",sentence,isStart,isEnd);
         audioService.sendAudio(ctx.channel(), audioPath, sentence, isStart, isEnd);
       } catch (Exception e) {
         logger.error("处理句子失败: {}", e.getMessage(), e);

--- a/src/main/java/com/xiaozhi/websocket/handler/TextWebSocketFrameHandler.java
+++ b/src/main/java/com/xiaozhi/websocket/handler/TextWebSocketFrameHandler.java
@@ -13,7 +13,6 @@ import com.xiaozhi.websocket.service.TextToSpeechService;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
-import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -108,7 +107,6 @@ public class TextWebSocketFrameHandler extends SimpleChannelInboundHandler<TextW
       }
     } catch (Exception e) {
       logger.error("处理消息失败", e);
-      ReferenceCountUtil.release(frame);
     }
   }
 
@@ -166,10 +164,10 @@ public class TextWebSocketFrameHandler extends SimpleChannelInboundHandler<TextW
    */
   private void handleHelloMessage(ChannelHandlerContext ctx, JsonNode jsonNode) {
     String sessionId = ctx.channel().attr(SESSION_ID).get();
-    logger.info("收到hello消息 - SessionId: {}", sessionId);
+    logger.info("收到hello消息 - SessionId: {}, JsonNode={}", sessionId,jsonNode);
 
     // 验证客户端hello消息
-    /*if (!jsonNode.path("transport").asText().equals("websocket")) {
+ /*   if (!jsonNode.path("transport").asText().equals("websocket")) {
       logger.warn("不支持的传输方式: {}", jsonNode.path("transport").asText());
       ctx.close();
       return;

--- a/src/main/java/com/xiaozhi/websocket/handler/WebSocketControlFrameHandler.java
+++ b/src/main/java/com/xiaozhi/websocket/handler/WebSocketControlFrameHandler.java
@@ -5,6 +5,8 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
+import io.netty.util.ReferenceCountUtil;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -13,23 +15,26 @@ import org.springframework.stereotype.Component;
  * WebSocket 控制帧处理器
  * 处理 WebSocket 协议的控制帧，如 Ping、Pong、Close 等
  */
+@Slf4j
 @Component
 public class WebSocketControlFrameHandler extends SimpleChannelInboundHandler<Object> {
 
   private static final Logger logger = LoggerFactory.getLogger(WebSocketControlFrameHandler.class);
 
   @Override
-  protected void channelRead0(ChannelHandlerContext ctx, Object frame) throws Exception {
+  protected void channelRead0(ChannelHandlerContext ctx, Object frame){
     if (frame instanceof PingWebSocketFrame) {
       // 处理 Ping 帧
       logger.debug("收到 Ping 帧");
       ctx.writeAndFlush(new PongWebSocketFrame(((PingWebSocketFrame) frame).content().retain()));
+
     } else if (frame instanceof CloseWebSocketFrame) {
       // 处理关闭帧
       logger.info("收到关闭帧");
       ctx.close();
     } else {
       // 将其他类型的帧传递给下一个处理器
+      ReferenceCountUtil.retain(frame); // 增加引用计数
       ctx.fireChannelRead(frame);
     }
   }

--- a/src/main/java/com/xiaozhi/websocket/handler/WebSocketExceptionHandler.java
+++ b/src/main/java/com/xiaozhi/websocket/handler/WebSocketExceptionHandler.java
@@ -25,8 +25,8 @@ public class WebSocketExceptionHandler extends ChannelInboundHandlerAdapter {
     String sessionId = ctx.channel().attr(SESSION_ID).get();
     String deviceId = ctx.channel().attr(DEVICE_ID).get();
 
-    logger.error("WebSocket处理异常 - SessionId: {}, DeviceId: {}, 异常: {}",
-        sessionId, deviceId, cause.getMessage(), cause);
+    /*logger.error("WebSocket处理异常 - SessionId: {}, DeviceId: {}, 异常: {}",
+        sessionId, deviceId, cause.getMessage(), cause);*/
 
     // 根据异常类型决定是否关闭连接
     if (isFatalException(cause)) {

--- a/src/main/java/com/xiaozhi/websocket/handler/WebSocketExceptionHandler.java
+++ b/src/main/java/com/xiaozhi/websocket/handler/WebSocketExceptionHandler.java
@@ -3,6 +3,7 @@ package com.xiaozhi.websocket.handler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.IllegalReferenceCountException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -25,8 +26,8 @@ public class WebSocketExceptionHandler extends ChannelInboundHandlerAdapter {
     String sessionId = ctx.channel().attr(SESSION_ID).get();
     String deviceId = ctx.channel().attr(DEVICE_ID).get();
 
-    /*logger.error("WebSocket处理异常 - SessionId: {}, DeviceId: {}, 异常: {}",
-        sessionId, deviceId, cause.getMessage(), cause);*/
+    logger.error("WebSocket处理异常 - SessionId: {}, DeviceId: {}, 异常: {}",
+        sessionId, deviceId, cause.getMessage(), cause);
 
     // 根据异常类型决定是否关闭连接
     if (isFatalException(cause)) {
@@ -40,10 +41,13 @@ public class WebSocketExceptionHandler extends ChannelInboundHandlerAdapter {
    */
   private boolean isFatalException(Throwable cause) {
     // 网络IO异常通常需要关闭连接
-    return cause instanceof java.io.IOException ||
-        cause instanceof java.net.SocketException ||
-        // 协议解析错误也可能需要关闭连接
-        cause instanceof io.netty.handler.codec.DecoderException ||
-        cause instanceof io.netty.handler.codec.CorruptedFrameException;
+    return cause instanceof java.io.IOException
+            || cause instanceof java.net.SocketException
+            // 协议解析错误也可能需要关闭连接
+            || cause instanceof io.netty.handler.codec.DecoderException
+            || cause instanceof io.netty.handler.codec.CorruptedFrameException
+            // 引用计数错误
+            || cause instanceof IllegalReferenceCountException
+            ;
   }
 }

--- a/src/main/java/com/xiaozhi/websocket/handler/WebSocketHandshakeHandler.java
+++ b/src/main/java/com/xiaozhi/websocket/handler/WebSocketHandshakeHandler.java
@@ -3,10 +3,12 @@ package com.xiaozhi.websocket.handler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.util.AttributeKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 /**
  * WebSocket 握手处理器
@@ -26,6 +28,17 @@ public class WebSocketHandshakeHandler extends ChannelInboundHandlerAdapter {
 
             // 提取设备ID
             String deviceId = req.headers().get("device-id");
+
+            // 如果请求头中没有 device-id，尝试从 URL 查询参数中获取
+            if (deviceId == null || deviceId.isEmpty()) {
+                // 解析 URL 查询参数
+                QueryStringDecoder decoder = new QueryStringDecoder(req.uri());
+                deviceId = Optional.ofNullable(decoder.parameters().get("device_id"))
+                        .filter(list -> !list.isEmpty())
+                        .map(list -> list.get(0))
+                        .orElse(null);
+            }
+
             if (deviceId == null || deviceId.isEmpty()) {
                 logger.warn("WebSocket连接缺少device-id头");
                 ctx.close();

--- a/src/main/java/com/xiaozhi/websocket/llm/LlmManager.java
+++ b/src/main/java/com/xiaozhi/websocket/llm/LlmManager.java
@@ -8,33 +8,20 @@ import com.xiaozhi.websocket.llm.api.StreamResponseListener;
 import com.xiaozhi.websocket.llm.factory.LlmServiceFactory;
 import com.xiaozhi.websocket.llm.memory.ChatMemory;
 import com.xiaozhi.websocket.llm.memory.ModelContext;
-
-import org.apache.logging.log4j.util.TriConsumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
 
 /**
  * LLM管理器
  * 负责管理和协调LLM相关功能
  */
+@Slf4j
 @Service
 public class LlmManager {
-    private static final Logger logger = LoggerFactory.getLogger(LlmManager.class);
-
-    // 标点符号模式（中英文标点）
-    private static final Pattern PUNCTUATION_PATTERN = Pattern.compile("[，。！？；,!?;]");
-
-    // 最小句子长度（字符数）
-    private static final int MIN_SENTENCE_LENGTH = 5;
 
     @Autowired
     private SysConfigService configService;
@@ -43,9 +30,10 @@ public class LlmManager {
     private ChatMemory chatMemory;
 
     // 设备LLM服务缓存，每个设备只保留一个服务
-    private Map<String, LlmService> deviceLlmServices = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String, LlmService> deviceLlmServices = new ConcurrentHashMap<>();
+
     // 设备当前使用的configId缓存
-    private Map<String, Integer> deviceConfigIds = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String, Integer> deviceConfigIds = new ConcurrentHashMap<>();
 
     /**
      * 处理用户查询（同步方式）
@@ -73,7 +61,7 @@ public class LlmManager {
             return llmService.chat(message, modelContext);
 
         } catch (Exception e) {
-            logger.error("处理查询时出错: {}", e.getMessage(), e);
+            log.error("处理查询时出错: {}", e.getMessage(), e);
             return "抱歉，我在处理您的请求时遇到了问题。请稍后再试。";
         }
     }
@@ -104,7 +92,7 @@ public class LlmManager {
             llmService.chatStream(message, modelContext, streamListener);
 
         } catch (Exception e) {
-            logger.error("处理流式查询时出错: {}", e.getMessage(), e);
+            log.error("处理流式查询时出错: {}", e.getMessage(), e);
             streamListener.onError(e);
         }
     }
@@ -124,7 +112,7 @@ public class LlmManager {
 
                 @Override
                 public void onStart() {
-                    logger.info("开始流式响应");
+                    log.info("开始流式响应");
                 }
 
                 @Override
@@ -138,12 +126,12 @@ public class LlmManager {
 
                 @Override
                 public void onComplete(String completeResponse) {
-                    logger.info("流式响应完成，完整响应: {}", completeResponse);
+                    log.info("流式响应完成，完整响应: {}", completeResponse);
                 }
 
                 @Override
                 public void onError(Throwable e) {
-                    logger.error("流式响应出错: {}", e.getMessage(), e);
+                    log.error("流式响应出错: {}", e.getMessage(), e);
                 }
             };
 
@@ -151,12 +139,12 @@ public class LlmManager {
             chatStream(device, message, streamListener);
 
         } catch (Exception e) {
-            logger.error("处理流式查询时出错: {}", e.getMessage(), e);
+            log.error("处理流式查询时出错: {}", e.getMessage(), e);
         }
     }
 
     /**
-     * 处理用户查询（流式方式，使用句子切分，带有开始和结束标志）
+     * 处理用户聊天（流式方式，使用句子切分，带有开始和结束标志）
      * 
      * @param device          设备信息
      * @param message         用户消息
@@ -164,97 +152,35 @@ public class LlmManager {
      */
     public void chatStreamBySentence(SysDevice device, String message,
             TriConsumer<String, Boolean, Boolean> sentenceHandler) {
+        log.info("分段处理文本,message={}",message);
         try {
-            final StringBuilder currentSentence = new StringBuilder();
-            final AtomicInteger sentenceCount = new AtomicInteger(0);
-            final StringBuilder fullResponse = new StringBuilder();
+            final SentenceProcessor processor = new SentenceProcessor(sentenceHandler);
 
-            // 用于跟踪是否有待处理的句子
-            final AtomicReference<String> pendingSentence = new AtomicReference<>(null);
-
-            // 创建流式响应监听器
-            StreamResponseListener streamListener = new StreamResponseListener() {
+            StreamResponseListener listener = new StreamResponseListener() {
                 @Override
                 public void onStart() {
                 }
 
                 @Override
                 public void onToken(String token) {
-                    // 将token添加到完整响应
-                    fullResponse.append(token);
-
-                    // 检查是否有待处理的句子
-                    String pending = pendingSentence.get();
-                    if (pending != null) {
-                        // 有待处理的句子，发送它
-                        boolean isStart = sentenceCount.get() == 0;
-                        boolean isEnd = false; // 中间句子不是结束
-                        sentenceHandler.accept(pending, isStart, isEnd);
-                        sentenceCount.incrementAndGet();
-                        pendingSentence.set(null);
-                    }
-
-                    // 将token添加到当前句子
-                    currentSentence.append(token);
-
-                    // 检查是否包含标点符号
-                    if (PUNCTUATION_PATTERN.matcher(token).matches()) {
-                        // 检查当前句子是否达到最小长度
-                        if (currentSentence.length() >= MIN_SENTENCE_LENGTH) {
-                            String sentence = currentSentence.toString().trim();
-
-                            // 不立即发送，而是将其设置为待处理
-                            pendingSentence.set(sentence);
-
-                            // 重置当前句子
-                            currentSentence.setLength(0);
-                        }
-                    }
+                    processor.processToken(token);
                 }
 
                 @Override
-                public void onComplete(String completeResponse) {
-                    // 处理待发送的句子（如果有）
-                    String pending = pendingSentence.getAndSet(null);
-                    if (pending != null) {
-                        // 如果这是第一个句子，isStart=true，如果是最后一个，isEnd=true
-                        boolean isStart = sentenceCount.get() == 0;
-                        boolean isEnd = true; // 最后一个待处理句子是结束
-                        sentenceHandler.accept(pending, isStart, isEnd);
-                        sentenceCount.incrementAndGet();
-                    }
-
-                    // 处理可能剩余的最后一个句子
-                    if (currentSentence.length() > 0) {
-                        String sentence = currentSentence.toString().trim();
-
-                        // 确定句子状态
-                        boolean isStart = sentenceCount.get() == 0;
-                        boolean isEnd = true; // 最后一个句子是结束
-
-                        sentenceHandler.accept(sentence, isStart, isEnd);
-                        sentenceCount.incrementAndGet();
-                    }
-
-                    // 如果没有任何句子被处理，发送一个空的结束标记
-                    if (sentenceCount.get() == 0) {
-                        sentenceHandler.accept("", true, true);
-                    }
+                public void onComplete(String response) {
+                    processor.finalizeProcessing();
                 }
 
                 @Override
                 public void onError(Throwable e) {
-                    logger.error("流式响应出错: {}", e.getMessage(), e);
-                    // 发送错误信号
-                    sentenceHandler.accept("抱歉，我在处理您的请求时遇到了问题。", true, true);
+                    processor.handleError(e);
                 }
             };
 
-            // 调用现有的流式方法
-            chatStream(device, message, streamListener);
+            chatStream(device, message, listener);
 
         } catch (Exception e) {
-            logger.error("处理流式查询时出错: {}", e.getMessage(), e);
+            log.error("处理流式查询时出错: {}", e.getMessage(), e);
             // 发送错误信号
             sentenceHandler.accept("抱歉，我在处理您的请求时遇到了问题。", true, true);
         }
@@ -316,10 +242,4 @@ public class LlmManager {
         chatMemory.clearMessages(deviceId);
     }
 
-    /**
-     * 三参数消费者接口
-     */
-    public interface TriConsumer<T, U, V> {
-        void accept(T t, U u, V v);
-    }
 }

--- a/src/main/java/com/xiaozhi/websocket/llm/SentenceProcessor.java
+++ b/src/main/java/com/xiaozhi/websocket/llm/SentenceProcessor.java
@@ -1,0 +1,72 @@
+package com.xiaozhi.websocket.llm;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+public class SentenceProcessor {
+
+        private final StringBuilder currentSentence = new StringBuilder();
+
+        private final AtomicInteger sentenceCount = new AtomicInteger(0);
+
+        private String pendingSentence;
+
+        private final TriConsumer<String, Boolean, Boolean> handler;
+
+        private static final Pattern SENTENCE_END_PATTERN = Pattern.compile("[,，.。!！?？;；:：]");
+
+        // 最大句子长度限制（字符数）
+        private static final int MAX_SENTENCE_LENGTH = 80;
+
+        // 最小句子长度（字符数）
+        private static final int MIN_SENTENCE_LENGTH = 10;
+
+        public SentenceProcessor(TriConsumer<String, Boolean, Boolean> handler) {
+            this.handler = handler;
+        }
+
+        void processToken(String token) {
+            currentSentence.append(token);
+            
+            // 判断句子结束
+            Matcher matcher = SENTENCE_END_PATTERN.matcher(currentSentence);
+            if (matcher.find() && currentSentence.length() >= MIN_SENTENCE_LENGTH) {
+                pendingSentence = currentSentence.toString().trim();
+                currentSentence.setLength(0);
+                dispatchPending();
+            }
+        }
+
+        void dispatchPending() {
+            if (pendingSentence != null) {
+                boolean isFirst = sentenceCount.get() == 0;
+                handler.accept(pendingSentence, isFirst, false);
+                sentenceCount.incrementAndGet();
+                pendingSentence = null;
+            }
+        }
+
+        void finalizeProcessing() {
+            dispatchPending(); // 处理剩余pending
+            
+            if (currentSentence.length() > 0) {
+                String finalSentence = currentSentence.toString().trim();
+                boolean isFirst = sentenceCount.get() == 0;
+                handler.accept(finalSentence, isFirst, true);
+                sentenceCount.incrementAndGet();
+            } else if (sentenceCount.get() == 0) {
+                handler.accept("", true, true);
+            }
+        }
+
+        void handleError(Throwable e) {
+            log.error("Stream processing error", e);
+            handler.accept("抱歉，我在处理您的请求时遇到了问题。", true, true);
+        }
+
+    }
+

--- a/src/main/java/com/xiaozhi/websocket/llm/SentenceProcessor.java
+++ b/src/main/java/com/xiaozhi/websocket/llm/SentenceProcessor.java
@@ -9,64 +9,82 @@ import java.util.regex.Pattern;
 @Slf4j
 public class SentenceProcessor {
 
-        private final StringBuilder currentSentence = new StringBuilder();
+    private final StringBuilder currentSentence = new StringBuilder();
+    private final AtomicInteger sentenceCount = new AtomicInteger(0);
+    private String pendingSentence;
+    private final TriConsumer<String, Boolean, Boolean> handler;
 
-        private final AtomicInteger sentenceCount = new AtomicInteger(0);
+    // 匹配可以作为分割点的标点（包括句子结束标点和适当的分割标点）
+    private static final Pattern SPLIT_POINT_PATTERN = 
+        Pattern.compile("[，,。！？.!?;；:：]|(\\.\\s)|(\\?\\s)|(!\\s)");
 
-        private String pendingSentence;
+    // 最小句子长度（避免过短的句子）
+    private static final int MIN_SENTENCE_LENGTH = 5;
 
-        private final TriConsumer<String, Boolean, Boolean> handler;
-
-        private static final Pattern SENTENCE_END_PATTERN = Pattern.compile("[,，.。!！?？;；:：]");
-
-        // 最大句子长度限制（字符数）
-        private static final int MAX_SENTENCE_LENGTH = 80;
-
-        // 最小句子长度（字符数）
-        private static final int MIN_SENTENCE_LENGTH = 10;
-
-        public SentenceProcessor(TriConsumer<String, Boolean, Boolean> handler) {
-            this.handler = handler;
-        }
-
-        void processToken(String token) {
-            currentSentence.append(token);
-            
-            // 判断句子结束
-            Matcher matcher = SENTENCE_END_PATTERN.matcher(currentSentence);
-            if (matcher.find() && currentSentence.length() >= MIN_SENTENCE_LENGTH) {
-                pendingSentence = currentSentence.toString().trim();
-                currentSentence.setLength(0);
-                dispatchPending();
-            }
-        }
-
-        void dispatchPending() {
-            if (pendingSentence != null) {
-                boolean isFirst = sentenceCount.get() == 0;
-                handler.accept(pendingSentence, isFirst, false);
-                sentenceCount.incrementAndGet();
-                pendingSentence = null;
-            }
-        }
-
-        void finalizeProcessing() {
-            dispatchPending(); // 处理剩余pending
-            
-            if (currentSentence.length() > 0) {
-                String finalSentence = currentSentence.toString().trim();
-                boolean isFirst = sentenceCount.get() == 0;
-                handler.accept(finalSentence, isFirst, true);
-                sentenceCount.incrementAndGet();
-            } else if (sentenceCount.get() == 0) {
-                handler.accept("", true, true);
-            }
-        }
-
-        void handleError(Throwable e) {
-            log.error("Stream processing error", e);
-            handler.accept("抱歉，我在处理您的请求时遇到了问题。", true, true);
-        }
-
+    public SentenceProcessor(TriConsumer<String, Boolean, Boolean> handler) {
+        this.handler = handler;
     }
 
+    void processToken(String token) {
+        currentSentence.append(token);
+        int lastSplitPos = findLastSplitPoint();
+        
+        // 如果有合适的分割点且满足最小长度要求，则分割
+        if (lastSplitPos > 0 && currentSentence.length() >= MIN_SENTENCE_LENGTH) {
+            String completeSentence = currentSentence.substring(0, lastSplitPos + 1).trim();
+            String remaining = currentSentence.substring(lastSplitPos + 1).trim();
+            
+            pendingSentence = completeSentence;
+            currentSentence.setLength(0);
+            currentSentence.append(remaining);
+            
+            dispatchPending();
+        }
+    }
+
+    // 查找最后一个合适的分割点
+    private int findLastSplitPoint() {
+        Matcher matcher = SPLIT_POINT_PATTERN.matcher(currentSentence);
+        int lastPos = -1;
+        
+        while (matcher.find()) {
+            // 确保分割点不在字符串的开头
+            if (matcher.start() > 0) {
+                lastPos = matcher.start();
+            }
+        }
+        
+        // 确保分割后的句子长度合理
+        if (lastPos > 0 && lastPos >= MIN_SENTENCE_LENGTH - 1) {
+            return lastPos;
+        }
+        return -1;
+    }
+
+    void dispatchPending() {
+        if (pendingSentence != null && !pendingSentence.isEmpty()) {
+            boolean isFirst = sentenceCount.get() == 0;
+            handler.accept(pendingSentence, isFirst, false);
+            sentenceCount.incrementAndGet();
+            pendingSentence = null;
+        }
+    }
+
+    void finalizeProcessing() {
+        dispatchPending(); // 处理剩余pending
+        
+        if (currentSentence.length() > 0) {
+            String finalSentence = currentSentence.toString().trim();
+            boolean isFirst = sentenceCount.get() == 0;
+            handler.accept(finalSentence, isFirst, true);
+            sentenceCount.incrementAndGet();
+        } else if (sentenceCount.get() == 0) {
+            handler.accept("", true, true);
+        }
+    }
+
+    void handleError(Throwable e) {
+        log.error("Stream processing error", e);
+        handler.accept("抱歉，我在处理您的请求时遇到了问题。", true, true);
+    }
+}

--- a/src/main/java/com/xiaozhi/websocket/llm/TriConsumer.java
+++ b/src/main/java/com/xiaozhi/websocket/llm/TriConsumer.java
@@ -1,0 +1,8 @@
+package com.xiaozhi.websocket.llm;
+
+/**
+ * 三参数消费者接口
+ */
+public interface TriConsumer<T, U, V> {
+    void accept(T t, U u, V v);
+}

--- a/src/main/java/com/xiaozhi/websocket/llm/api/AbstractLlmService.java
+++ b/src/main/java/com/xiaozhi/websocket/llm/api/AbstractLlmService.java
@@ -3,8 +3,8 @@ package com.xiaozhi.websocket.llm.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xiaozhi.entity.SysMessage;
 import com.xiaozhi.websocket.llm.memory.ModelContext;
-import okhttp3.OkHttpClient;
 import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
  * 实现一些通用功能
  */
 public abstract class AbstractLlmService implements LlmService {
+
     protected static final Logger logger = LoggerFactory.getLogger(AbstractLlmService.class);
     protected static final ObjectMapper objectMapper = new ObjectMapper();
     protected static final OkHttpClient client = new OkHttpClient.Builder()
@@ -32,7 +33,7 @@ public abstract class AbstractLlmService implements LlmService {
     protected static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
     // 设备历史记录缓存，键为deviceId，值为该设备的历史消息
-    protected Map<String, List<SysMessage>> deviceHistoryCache = new ConcurrentHashMap<>();
+    protected ConcurrentHashMap<String, List<SysMessage>> deviceHistoryCache = new ConcurrentHashMap<>();
 
     // 历史记录默认限制数量
     protected static final int DEFAULT_HISTORY_LIMIT = 10;
@@ -67,8 +68,8 @@ public abstract class AbstractLlmService implements LlmService {
     protected void initializeHistory(ModelContext modelContext) {
         String deviceId = modelContext.getDeviceId();
         if (!deviceHistoryCache.containsKey(deviceId)) {
-            // 从数据库加载历史记录
-            List<SysMessage> history = modelContext.getMessages(DEFAULT_HISTORY_LIMIT); // 这里后期可以设置 limit，来自定义历史记录条数
+            // 从数据库加载历史记录,可以设置 limit，来自定义历史记录条数
+            List<SysMessage> history = modelContext.getMessages(DEFAULT_HISTORY_LIMIT);
             deviceHistoryCache.put(deviceId, history);
             logger.info("已初始化设备 {} 的历史记录缓存，共 {} 条消息", deviceId, history.size());
         }

--- a/src/main/java/com/xiaozhi/websocket/llm/factory/LlmServiceFactory.java
+++ b/src/main/java/com/xiaozhi/websocket/llm/factory/LlmServiceFactory.java
@@ -24,7 +24,8 @@ public class LlmServiceFactory {
      * @param model 模型名称
      * @return LLM服务
      */
-    public static LlmService createLlmService(String provider, String endpoint, String appId, String apiKey, String apiSecret, String model) {
+    public static LlmService createLlmService(String provider, String endpoint, String appId,
+                                              String apiKey, String apiSecret, String model) {
         provider = provider.toLowerCase();
         
         switch (provider) {

--- a/src/main/java/com/xiaozhi/websocket/llm/memory/DatabaseChatMemory.java
+++ b/src/main/java/com/xiaozhi/websocket/llm/memory/DatabaseChatMemory.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -44,7 +45,7 @@ public class DatabaseChatMemory implements ChatMemory {
             message.setSender(sender);
             message.setMessage(content);
             message.setRoleId(roleId);
-            if (sender == "assistant") {
+            if (Objects.equals(sender, "assistant")) {
                 message.setAudioPath(textToSpeechService.textToSpeech(content));
             }
             messageService.add(message);

--- a/src/main/java/com/xiaozhi/websocket/service/AudioService.java
+++ b/src/main/java/com/xiaozhi/websocket/service/AudioService.java
@@ -124,7 +124,7 @@ public class AudioService {
      * 初始化音频队列
      */
     public void initializeSession(String sessionId) {
-        // 初始化音频队列,不存在时,新建语音队列
+        // 初始化音频队列,不存在时,新建语音队列,已存在时不变
 //        logger.info("初始化音频队列和处理状态, sessionId = {}", sessionId);
         audioQueues.putIfAbsent(sessionId, new LinkedBlockingQueue<>());
         isProcessingMap.putIfAbsent(sessionId, new AtomicBoolean(false));
@@ -273,11 +273,10 @@ public class AudioService {
                 audioQueues.get(sessionId).add(task);
                 if (isFirstText) {
                     sendStart(channel);
-                }
-
-                // 如果当前没有处理任务，开始处理
-                if (isProcessingMap.get(sessionId).compareAndSet(false, true)) {
-                    processNextAudio(channel);
+                    // 如果当前没有处理任务，开始处理,确保从第一个句子开始
+                    if (isProcessingMap.get(sessionId).compareAndSet(false, true)) {
+                        processNextAudio(channel);
+                    }
                 }
             } catch (Exception e) {
                 logger.error("音频预处理失败: {}", e.getMessage(), e);

--- a/src/main/java/com/xiaozhi/websocket/service/MessageService.java
+++ b/src/main/java/com/xiaozhi/websocket/service/MessageService.java
@@ -41,9 +41,9 @@ public class MessageService {
             response.put("state", state);
 
             channel.writeAndFlush(new TextWebSocketFrame(response.toString()));
-            logger.info("发送消息 - SessionId: {}, Type: {}, State: {}", sessionId, type, state);
+            logger.info("消息发送成功 - SessionId: {}, Type: {}, State: {}", sessionId, type, state);
         } catch (Exception e) {
-            logger.error("发送消息时发生异常: {}", e.getMessage(), e);
+            logger.error("消息发送异常: {}", e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/xiaozhi/websocket/service/TextToSpeechService.java
+++ b/src/main/java/com/xiaozhi/websocket/service/TextToSpeechService.java
@@ -17,9 +17,9 @@ public class TextToSpeechService {
     private TtsServiceFactory ttsServiceFactory;
 
     public String textToSpeech(String message) throws Exception {
-        // 获取默认TTS服务
-        TtsService ttsService = ttsServiceFactory.getTtsService();
         try {
+            // 获取默认TTS服务
+            TtsService ttsService = ttsServiceFactory.getTtsService();
             // 使用TTS服务将文本转换为语音
             return ttsService.textToSpeech(message);
         } catch (Exception e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,9 @@ spring.datasource.hikari.connection-test-query=SELECT 1
 logging.level.org.springframework=INFO
 logging.level.com.xiaozhi.dao=DEBUG
 logging.level.com.xiaozhi.websocket=DEBUG
+#logging.level.io.netty=DEBUG
 # 设置根日志级别，确保所有日志都能输出
+logging.config=classpath:logback-spring.xml
 logging.level.root=INFO
 # 添加这一行来禁用Groovy模板位置检查
 spring.groovy.template.check-template-location=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
-server.port=8092
+server.port=8081
+netty.websocket.port=8082
 spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 
 spring.datasource.url=jdbc:mysql://localhost:3306/xiaozhi?useUnicode=true&characterEncoding=utf8&serverTimezone=GMT%2B8&useSSL=false&allowPublicKeyRetrieval=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,7 @@ spring.datasource.hikari.connection-test-query=SELECT 1
 logging.level.org.springframework=INFO
 logging.level.com.xiaozhi.dao=DEBUG
 logging.level.com.xiaozhi.websocket=DEBUG
-#logging.level.io.netty=DEBUG
+logging.level.io.netty=DEBUG
 # 设置根日志级别，确保所有日志都能输出
 logging.config=classpath:logback-spring.xml
 logging.level.root=INFO

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,41 @@
+<configuration>
+
+    <!-- 格式化输出：%date表示日期，%thread表示线程名，%-5level：级别从左显示5个字符宽度 %msg：日志消息，%n是换行符-->
+    <property name="LOG_PATTERN" value="%date{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" />
+    <!-- 定义日志存储的路径，不要配置相对路径 -->
+    <property name="FILE_PATH" value="usr/logs/demo.%d{yyyy-MM-dd}.%i.log" />
+
+    <!-- 控制台输出日志 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- 按照上面配置的LOG_PATTERN来打印日志 -->
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!--每天生成一个日志文件，保存15天的日志文件。rollingFile是用来切分文件的 -->
+    <appender name="FILE"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${FILE_PATH}</fileNamePattern>
+            <!-- keep 15 days' worth of history -->
+            <maxHistory>15</maxHistory>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- 日志文件的最大大小，超过这个大小重新生成一个文件 -->
+                <maxFileSize>50MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+    <!-- project default level -->
+    <logger name="src" level="INFO" />
+
+    <!-- 日志输出级别 常用的日志级别按照从高到低依次为：ERROR、WARN、INFO、DEBUG。 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/usr/logs/demo.2025-04-05.0.log
+++ b/usr/logs/demo.2025-04-05.0.log
@@ -1,0 +1,626 @@
+20:30:44.440 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 26084 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+20:30:44.443 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+20:30:45.479 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+20:30:45.484 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+20:30:45.486 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+20:30:45.486 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+20:30:45.612 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+20:30:45.612 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1118 ms
+20:30:46.277 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+20:30:46.282 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+20:30:46.728 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xd91c4c7d] REGISTERED
+20:30:46.729 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xd91c4c7d] BIND: 0.0.0.0/0.0.0.0:8091
+20:30:46.731 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+20:30:46.732 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xd91c4c7d, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+20:30:47.170 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+20:30:47.198 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+20:30:47.209 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+20:30:47.840 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+20:30:47.840 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+20:30:47.840 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+20:30:47.840 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+20:30:47.840 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+20:30:47.854 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 3.891 seconds (JVM running for 5.114)
+20:30:47.860 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+20:30:47.860 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+20:30:47.860 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+20:30:48.795 [RMI TCP Connection(3)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+20:30:48.795 [RMI TCP Connection(2)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+20:30:48.795 [RMI TCP Connection(3)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+20:30:48.795 [RMI TCP Connection(2)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+20:30:48.797 [RMI TCP Connection(2)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
+20:30:48.930 [RMI TCP Connection(3)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+20:33:03.578 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+20:33:03.579 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xd91c4c7d, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+20:33:03.580 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xd91c4c7d, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+20:33:03.580 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+20:33:03.585 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+20:33:07.955 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 9772 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+20:33:07.957 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+20:33:09.076 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+20:33:09.083 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+20:33:09.084 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+20:33:09.085 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+20:33:09.202 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+20:33:09.202 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1196 ms
+20:33:09.939 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+20:33:09.944 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+20:33:10.456 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe39ca144] REGISTERED
+20:33:10.457 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe39ca144] BIND: 0.0.0.0/0.0.0.0:8091
+20:33:10.459 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+20:33:10.460 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe39ca144, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+20:33:10.917 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+20:33:10.945 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+20:33:10.956 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+20:33:11.578 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+20:33:11.578 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+20:33:11.578 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+20:33:11.578 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+20:33:11.578 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+20:33:11.591 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.133 seconds (JVM running for 5.129)
+20:33:11.597 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+20:33:11.597 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+20:33:11.597 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+20:33:12.359 [RMI TCP Connection(3)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+20:33:12.359 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+20:33:12.360 [RMI TCP Connection(4)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+20:33:12.360 [RMI TCP Connection(4)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+20:33:12.362 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 3 ms
+20:33:12.509 [RMI TCP Connection(4)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+20:34:01.848 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe39ca144, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xa673cdf5, L:/127.0.0.1:8091 - R:/127.0.0.1:61881]
+20:34:01.849 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe39ca144, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+20:34:01.889 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:61881
+20:34:01.911 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: a673cdf5, DeviceId: web_test_device
+20:34:01.941 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe39ca144, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x6a03b207, L:/127.0.0.1:8091 - R:/127.0.0.1:61882]
+20:34:01.942 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe39ca144, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+20:34:01.945 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:61882
+20:34:01.946 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 6a03b207, DeviceId: web_test_device
+20:34:01.988 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+20:34:02.006 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+20:34:02.017 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+20:34:02.027 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+20:34:02.027 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+20:34:02.033 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+20:34:02.039 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 6a03b207, DeviceId: web_test_device
+20:34:02.039 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+20:34:02.045 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 6a03b207
+20:34:02.046 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+20:34:05.841 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+20:34:05.842 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+20:34:05.846 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+20:34:05.847 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+20:34:05.847 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+20:34:05.849 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+20:34:05.857 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 6a03b207, DeviceId: web_test_device
+20:34:05.857 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"detect","text":"你好"}
+20:34:05.857 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 6a03b207, State: detect, Mode: manual
+20:34:05.857 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 检测到唤醒词: 你好
+20:34:05.857 [nioEventLoopGroup-3-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 6a03b207, Type: stt, State: start, Text: 你好
+20:34:05.861 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==>  Preparing: SELECT sys_config.configId, sys_config.userId, sys_config.configName, sys_config.configDesc, sys_config.configType, sys_config.provider, sys_config.appId, sys_config.apiKey, sys_config.apiSecret, sys_config.apiUrl, sys_config.isDefault, sys_config.state, sys_config.createTime FROM sys_config WHERE sys_config.configId = ?
+20:34:05.862 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==> Parameters: 1(Integer)
+20:34:05.864 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - <==      Total: 1
+20:34:06.374 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==>  Preparing: SELECT sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName, sys_role.ttsId, sys_role.userId, sys_role.state, sys_role.createTime FROM sys_role WHERE roleId = ?
+20:34:06.375 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==> Parameters: 3(Integer)
+20:34:06.376 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - <==      Total: 1
+20:34:06.416 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==>  Preparing: SELECT count(0) FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ?
+20:34:06.417 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==> Parameters: web_test_device(String)
+20:34:06.418 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - <==      Total: 1
+20:34:06.419 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==>  Preparing: SELECT sys_message.messageId, sys_message.message, sys_message.sender, sys_message.audioPath, sys_message.state, sys_message.createTime , sys_device.deviceId, sys_device.deviceName, sys_device.userId , sys_role.roleId, sys_role.roleName, sys_role.voiceName FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ? ORDER BY sys_message.createTime DESC LIMIT ?
+20:34:06.419 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==> Parameters: web_test_device(String), 10(Integer)
+20:34:06.425 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - <==      Total: 10
+20:34:06.425 [nioEventLoopGroup-3-2] INFO  c.x.w.llm.api.AbstractLlmService - 已初始化设备 web_test_device 的历史记录缓存，共 10 条消息
+20:34:06.425 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+20:34:06.427 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 6a03b207(String), user(String), 3(Integer), 你好(String), null
+20:34:06.432 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+20:37:07.981 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+20:37:07.984 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe39ca144, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+20:37:07.984 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:61881
+20:37:07.985 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe39ca144, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+20:37:07.985 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+20:37:07.992 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+20:37:12.379 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 5240 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+20:37:12.385 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+20:37:13.522 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+20:37:13.528 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+20:37:13.529 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+20:37:13.529 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+20:37:13.647 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+20:37:13.648 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1197 ms
+20:37:14.348 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+20:37:14.353 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+20:37:14.806 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662] REGISTERED
+20:37:14.807 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662] BIND: 0.0.0.0/0.0.0.0:8091
+20:37:14.809 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+20:37:14.811 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+20:37:15.262 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+20:37:15.288 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+20:37:15.300 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+20:37:15.936 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+20:37:15.936 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+20:37:15.936 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+20:37:15.936 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+20:37:15.936 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+20:37:15.949 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.043 seconds (JVM running for 5.137)
+20:37:15.956 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+20:37:15.956 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+20:37:15.956 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+20:37:16.659 [RMI TCP Connection(1)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+20:37:16.659 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+20:37:16.660 [RMI TCP Connection(2)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+20:37:16.660 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+20:37:16.662 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 3 ms
+20:37:16.827 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+20:37:21.548 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xdd375696, L:/127.0.0.1:8091 - R:/127.0.0.1:62060]
+20:37:21.550 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+20:37:21.597 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:62060
+20:37:21.620 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: dd375696, DeviceId: web_test_device
+20:37:21.644 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x2421428f, L:/127.0.0.1:8091 - R:/127.0.0.1:62061]
+20:37:21.645 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+20:37:21.648 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:62061
+20:37:21.649 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 2421428f, DeviceId: web_test_device
+20:37:21.698 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+20:37:21.715 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+20:37:21.728 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+20:37:21.737 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+20:37:21.737 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+20:37:21.742 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+20:37:21.748 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 2421428f, DeviceId: web_test_device
+20:37:21.748 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+20:37:21.755 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 2421428f
+20:37:21.756 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+20:37:26.341 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+20:37:26.342 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+20:37:26.345 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+20:37:26.346 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+20:37:26.346 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+20:37:26.347 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+20:37:26.355 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 2421428f, DeviceId: web_test_device
+20:37:26.355 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"detect","text":"你好"}
+20:37:26.355 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 2421428f, State: detect, Mode: manual
+20:37:26.356 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 检测到唤醒词: 你好
+20:37:26.356 [nioEventLoopGroup-3-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 2421428f, Type: stt, State: start, Text: 你好
+20:37:26.362 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==>  Preparing: SELECT sys_config.configId, sys_config.userId, sys_config.configName, sys_config.configDesc, sys_config.configType, sys_config.provider, sys_config.appId, sys_config.apiKey, sys_config.apiSecret, sys_config.apiUrl, sys_config.isDefault, sys_config.state, sys_config.createTime FROM sys_config WHERE sys_config.configId = ?
+20:37:26.362 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==> Parameters: 1(Integer)
+20:37:26.365 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - <==      Total: 1
+20:37:26.887 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==>  Preparing: SELECT sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName, sys_role.ttsId, sys_role.userId, sys_role.state, sys_role.createTime FROM sys_role WHERE roleId = ?
+20:37:26.887 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==> Parameters: 3(Integer)
+20:37:26.888 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - <==      Total: 1
+20:37:26.939 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==>  Preparing: SELECT count(0) FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ?
+20:37:26.939 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==> Parameters: web_test_device(String)
+20:37:26.941 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - <==      Total: 1
+20:37:26.945 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==>  Preparing: SELECT sys_message.messageId, sys_message.message, sys_message.sender, sys_message.audioPath, sys_message.state, sys_message.createTime , sys_device.deviceId, sys_device.deviceName, sys_device.userId , sys_role.roleId, sys_role.roleName, sys_role.voiceName FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ? ORDER BY sys_message.createTime DESC LIMIT ?
+20:37:26.945 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==> Parameters: web_test_device(String), 10(Integer)
+20:37:26.950 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - <==      Total: 10
+20:37:26.951 [nioEventLoopGroup-3-2] INFO  c.x.w.llm.api.AbstractLlmService - 已初始化设备 web_test_device 的历史记录缓存，共 10 条消息
+20:37:26.953 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+20:37:26.954 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 2421428f(String), user(String), 3(Integer), 你好(String), null
+20:37:26.957 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+20:37:30.588 [pool-2-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 2421428f, Type: tts, State: start
+20:37:30.589 [pool-1-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 2421428f, Type: tts, State: sentence_start, Text: 你好！如果你有任何问题或者需要帮助，
+20:37:30.599 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+20:37:30.600 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+20:37:30.605 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+20:37:30.609 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 2421428f, DeviceId: web_test_device
+20:37:30.609 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:62061
+20:37:30.663 [pool-1-thread-1] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+20:37:32.044 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+20:37:32.045 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 2421428f(String), assistant(String), 3(Integer), 你好！如果你有任何问题或者需要帮助，随时告诉我，我会尽力为你提供帮助。(String), audio/0d720c44bb2a447cb86396e60ead6555.mp3(String)
+20:37:32.047 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+20:37:48.609 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xb151eb2b, L:/127.0.0.1:8091 - R:/127.0.0.1:62087]
+20:37:48.609 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+20:37:48.616 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:62087
+20:37:48.617 [nioEventLoopGroup-3-3] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: b151eb2b, DeviceId: web_test_device
+20:37:48.639 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xbd9c4433, L:/127.0.0.1:8091 - R:/127.0.0.1:62088]
+20:37:48.639 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+20:37:48.642 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:62088
+20:37:48.642 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: bd9c4433, DeviceId: web_test_device
+20:37:48.649 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+20:37:48.649 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+20:37:48.650 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+20:37:48.652 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+20:37:48.652 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+20:37:48.654 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+20:37:48.661 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: bd9c4433, DeviceId: web_test_device
+20:37:48.661 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+20:37:48.661 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: bd9c4433
+20:37:48.661 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+20:42:21.616 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: dd375696
+20:42:48.624 [nioEventLoopGroup-3-3] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: b151eb2b
+20:42:48.671 [nioEventLoopGroup-3-4] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 写空闲超时 - SessionId: bd9c4433
+20:42:48.671 [nioEventLoopGroup-3-4] WARN  c.x.w.h.WebSocketHeartbeatHandler - 全空闲超时 - SessionId: bd9c4433, 关闭连接
+20:42:48.676 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+20:42:48.676 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+20:42:48.682 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+20:42:48.686 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: bd9c4433, DeviceId: web_test_device
+20:42:48.686 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:62088
+20:47:21.627 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: dd375696
+20:47:48.634 [nioEventLoopGroup-3-3] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: b151eb2b
+20:49:09.712 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x5da382d0, L:/127.0.0.1:8091 - R:/127.0.0.1:64887]
+20:49:09.713 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+20:49:09.713 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:64887
+20:49:09.714 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 5da382d0, DeviceId: web_test_device
+20:49:09.737 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xbc23329e, L:/127.0.0.1:8091 - R:/127.0.0.1:64888]
+20:49:09.738 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+20:49:09.739 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:64888
+20:49:09.739 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: bc23329e, DeviceId: web_test_device
+20:49:09.746 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+20:49:09.746 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+20:49:09.758 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+20:49:09.760 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+20:49:09.760 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+20:49:09.763 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+20:49:09.768 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: bc23329e, DeviceId: web_test_device
+20:49:09.768 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+20:49:09.768 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: bc23329e
+20:49:09.768 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+20:49:14.834 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+20:49:14.835 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+20:49:14.838 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+20:49:14.841 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+20:49:14.842 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+20:49:14.843 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+20:49:14.848 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: bc23329e, DeviceId: web_test_device
+20:49:14.848 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"detect","text":"你好"}
+20:49:14.848 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: bc23329e, State: detect, Mode: manual
+20:49:14.848 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 检测到唤醒词: 你好
+20:49:14.849 [nioEventLoopGroup-3-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: bc23329e, Type: stt, State: start, Text: 你好
+20:49:14.850 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+20:49:14.851 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), bc23329e(String), user(String), 3(Integer), 你好(String), null
+20:49:14.853 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+20:49:18.798 [pool-2-thread-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: bc23329e, Type: tts, State: start
+20:49:18.799 [pool-1-thread-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: bc23329e, Type: tts, State: sentence_start, Text: 你好！有什么我可以帮你的吗？
+20:49:18.804 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+20:49:18.804 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+20:49:18.806 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+20:49:18.809 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: bc23329e, DeviceId: web_test_device
+20:49:18.809 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:64888
+20:49:18.868 [pool-1-thread-2] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+20:49:19.392 [pool-1-thread-2] WARN  c.x.websocket.service.MessageService - 无法发送消息 - 通道不活跃或为null
+20:49:19.392 [pool-1-thread-2] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+20:49:20.185 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+20:49:20.186 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), bc23329e(String), assistant(String), 3(Integer), 你好！有什么我可以帮你的吗？如果你有任何问题或者需要帮助，请随时告诉我。(String), audio/3fc8c8c29c3a48da87dca797b08e1925.mp3(String)
+20:49:20.188 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+20:52:21.630 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: dd375696
+20:52:48.643 [nioEventLoopGroup-3-3] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: b151eb2b
+20:54:09.719 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 5da382d0
+20:54:17.593 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+20:54:17.594 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+20:54:17.594 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xff61b662, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+20:54:17.595 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:64887
+20:54:17.595 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:62060
+20:54:17.595 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:62087
+20:54:17.599 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+20:54:17.604 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+20:54:22.673 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 21656 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+20:54:22.676 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+20:54:24.004 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+20:54:24.013 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+20:54:24.014 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+20:54:24.014 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+20:54:24.268 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+20:54:24.268 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1541 ms
+20:54:25.248 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+20:54:25.254 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+20:54:25.747 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x6c164b1c] REGISTERED
+20:54:25.748 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x6c164b1c] BIND: 0.0.0.0/0.0.0.0:8091
+20:54:25.750 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+20:54:25.752 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x6c164b1c, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+20:54:26.241 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+20:54:26.273 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+20:54:26.285 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+20:54:26.956 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+20:54:26.956 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+20:54:26.956 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+20:54:26.956 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+20:54:26.957 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+20:54:26.969 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.91 seconds (JVM running for 6.166)
+20:54:26.975 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+20:54:26.976 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+20:54:26.976 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+20:54:27.955 [RMI TCP Connection(3)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+20:54:27.955 [RMI TCP Connection(2)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+20:54:27.955 [RMI TCP Connection(3)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+20:54:27.955 [RMI TCP Connection(2)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+20:54:27.957 [RMI TCP Connection(2)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
+20:54:28.106 [RMI TCP Connection(3)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+21:04:11.790 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x6c164b1c, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xebc6fbb9, L:/127.0.0.1:8091 - R:/127.0.0.1:49620]
+21:04:11.791 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x6c164b1c, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:04:11.835 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:49620
+21:04:11.859 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: ebc6fbb9, DeviceId: web_test_device
+21:04:11.913 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:04:11.926 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:04:11.937 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:04:11.946 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:04:11.946 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:04:11.948 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:04:11.952 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: ebc6fbb9, DeviceId: web_test_device
+21:04:11.952 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:04:11.958 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: ebc6fbb9
+21:04:11.959 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:04:15.294 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:04:15.295 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:04:15.297 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:04:15.298 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:04:15.298 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:04:15.303 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:04:15.308 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: ebc6fbb9, DeviceId: web_test_device
+21:04:15.308 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"detect","text":"你好"}
+21:04:15.308 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: ebc6fbb9, State: detect, Mode: manual
+21:04:15.308 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 检测到唤醒词: 你好
+21:04:15.309 [nioEventLoopGroup-3-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: ebc6fbb9, Type: stt, State: start, Text: 你好
+21:04:15.314 [nioEventLoopGroup-3-1] DEBUG c.x.d.ConfigMapper.selectConfigById - ==>  Preparing: SELECT sys_config.configId, sys_config.userId, sys_config.configName, sys_config.configDesc, sys_config.configType, sys_config.provider, sys_config.appId, sys_config.apiKey, sys_config.apiSecret, sys_config.apiUrl, sys_config.isDefault, sys_config.state, sys_config.createTime FROM sys_config WHERE sys_config.configId = ?
+21:04:15.315 [nioEventLoopGroup-3-1] DEBUG c.x.d.ConfigMapper.selectConfigById - ==> Parameters: 1(Integer)
+21:04:15.316 [nioEventLoopGroup-3-1] DEBUG c.x.d.ConfigMapper.selectConfigById - <==      Total: 1
+21:04:15.864 [nioEventLoopGroup-3-1] DEBUG c.x.dao.RoleMapper.selectRoleById - ==>  Preparing: SELECT sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName, sys_role.ttsId, sys_role.userId, sys_role.state, sys_role.createTime FROM sys_role WHERE roleId = ?
+21:04:15.864 [nioEventLoopGroup-3-1] DEBUG c.x.dao.RoleMapper.selectRoleById - ==> Parameters: 3(Integer)
+21:04:15.865 [nioEventLoopGroup-3-1] DEBUG c.x.dao.RoleMapper.selectRoleById - <==      Total: 1
+21:04:15.906 [nioEventLoopGroup-3-1] DEBUG c.x.dao.MessageMapper.query_COUNT - ==>  Preparing: SELECT count(0) FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ?
+21:04:15.907 [nioEventLoopGroup-3-1] DEBUG c.x.dao.MessageMapper.query_COUNT - ==> Parameters: web_test_device(String)
+21:04:15.908 [nioEventLoopGroup-3-1] DEBUG c.x.dao.MessageMapper.query_COUNT - <==      Total: 1
+21:04:15.910 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.query - ==>  Preparing: SELECT sys_message.messageId, sys_message.message, sys_message.sender, sys_message.audioPath, sys_message.state, sys_message.createTime , sys_device.deviceId, sys_device.deviceName, sys_device.userId , sys_role.roleId, sys_role.roleName, sys_role.voiceName FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ? ORDER BY sys_message.createTime DESC LIMIT ?
+21:04:15.911 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.query - ==> Parameters: web_test_device(String), 10(Integer)
+21:04:15.915 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.query - <==      Total: 10
+21:04:15.915 [nioEventLoopGroup-3-1] INFO  c.x.w.llm.api.AbstractLlmService - 已初始化设备 web_test_device 的历史记录缓存，共 10 条消息
+21:04:15.916 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+21:04:15.917 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), ebc6fbb9(String), user(String), 3(Integer), 你好(String), null
+21:04:15.919 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+21:04:19.477 [pool-2-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: ebc6fbb9, Type: tts, State: start
+21:04:19.478 [pool-1-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: ebc6fbb9, Type: tts, State: sentence_start, Text: 你好！如果你有任何问题或需要帮助，
+21:04:19.485 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:04:19.485 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:04:19.487 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:04:19.491 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: ebc6fbb9, DeviceId: web_test_device
+21:04:19.492 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:49620
+21:04:19.544 [pool-1-thread-1] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+21:04:21.261 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+21:04:21.262 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), ebc6fbb9(String), assistant(String), 3(Integer), 你好！如果你有任何问题或需要帮助，我在这里随时为你服务。请告诉我你的需求。(String), audio/d7895a10ddc24d26933284b1bbfca05f.mp3(String)
+21:04:21.267 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+21:12:50.214 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+21:12:50.214 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x6c164b1c, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+21:12:50.215 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x6c164b1c, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+21:12:50.217 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+21:12:50.221 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+21:12:54.387 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 30572 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+21:12:54.390 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+21:12:55.494 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+21:12:55.500 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+21:12:55.502 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+21:12:55.502 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+21:12:55.622 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+21:12:55.622 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1183 ms
+21:12:56.287 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+21:12:56.291 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+21:12:56.296 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+21:12:56.297 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+21:12:56.305 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+21:12:56.311 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+21:12:56.311 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+21:12:56.318 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+21:12:56.318 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+21:12:56.318 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+21:12:56.319 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+21:12:56.319 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+21:12:56.319 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+21:12:56.320 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+21:12:56.321 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+21:12:56.321 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+21:12:56.321 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+21:12:56.321 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+21:12:56.321 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+21:12:56.321 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+21:12:56.321 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+21:12:56.322 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+21:12:56.322 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+21:12:56.323 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+21:12:56.323 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+21:12:56.324 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+21:12:56.324 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+21:12:56.326 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+21:12:56.359 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 30572 (auto-detected)
+21:12:56.360 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+21:12:56.360 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+21:12:56.667 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+21:12:56.668 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+21:12:56.684 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+21:12:56.692 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+21:12:56.692 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+21:12:56.703 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+21:12:56.703 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+21:12:56.703 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+21:12:56.703 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+21:12:56.703 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+21:12:56.703 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+21:12:56.704 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+21:12:56.704 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+21:12:56.704 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+21:12:56.704 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+21:12:56.704 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+21:12:56.704 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+21:12:56.711 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+21:12:56.711 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+21:12:56.711 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+21:12:56.712 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+21:12:56.724 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x0f8c93bf] REGISTERED
+21:12:56.725 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x0f8c93bf] BIND: 0.0.0.0/0.0.0.0:8091
+21:12:56.726 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+21:12:56.727 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x0f8c93bf, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+21:12:57.132 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+21:12:57.156 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+21:12:57.166 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+21:12:57.771 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:12:57.772 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+21:12:57.772 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+21:12:57.772 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+21:12:57.772 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:12:57.785 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 3.891 seconds (JVM running for 4.949)
+21:12:57.792 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+21:12:57.792 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+21:12:57.792 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+21:12:58.810 [RMI TCP Connection(2)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+21:12:58.811 [RMI TCP Connection(2)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+21:12:58.811 [RMI TCP Connection(3)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+21:12:58.811 [RMI TCP Connection(3)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+21:12:58.812 [RMI TCP Connection(2)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+21:12:58.946 [RMI TCP Connection(3)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+21:13:12.545 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x0f8c93bf, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x97b082cc, L:/127.0.0.1:8091 - R:/127.0.0.1:50379]
+21:13:12.546 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x0f8c93bf, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:13:12.556 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+21:13:12.556 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+21:13:12.557 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@63be82d
+21:13:12.586 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+21:13:12.586 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+21:13:12.589 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:50379
+21:13:12.592 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+21:13:12.593 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+21:13:12.593 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+21:13:12.593 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+21:13:12.593 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+21:13:12.612 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 97b082cc, DeviceId: web_test_device
+21:13:12.615 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x97b082cc, L:/127.0.0.1:8091 - R:/127.0.0.1:50379] WebSocket version V13 server handshake
+21:13:12.617 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: 9JjoVHz3Z/8Z+oubHPgPRA==, response: dgXKjc0w+GsGnHp/kW5aCFbD4D8=
+21:13:12.659 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:13:12.672 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:13:12.698 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:13:12.707 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:13:12.708 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:13:12.710 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:13:12.715 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 97b082cc, DeviceId: web_test_device
+21:13:12.716 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:13:12.722 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 97b082cc
+21:13:12.722 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:13:12.731 [nioEventLoopGroup-3-1] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 97b082cc, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:13:46.252 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:13:46.253 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:13:46.256 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:13:46.258 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:13:46.258 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:13:46.260 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:13:46.268 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 97b082cc, DeviceId: web_test_device
+21:13:46.269 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"detect","text":"你好"}
+21:13:46.269 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 97b082cc, State: detect, Mode: manual
+21:13:46.269 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 检测到唤醒词: 你好
+21:13:46.270 [nioEventLoopGroup-3-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 97b082cc, Type: stt, State: start, Text: 你好
+21:13:46.275 [nioEventLoopGroup-3-1] DEBUG c.x.d.ConfigMapper.selectConfigById - ==>  Preparing: SELECT sys_config.configId, sys_config.userId, sys_config.configName, sys_config.configDesc, sys_config.configType, sys_config.provider, sys_config.appId, sys_config.apiKey, sys_config.apiSecret, sys_config.apiUrl, sys_config.isDefault, sys_config.state, sys_config.createTime FROM sys_config WHERE sys_config.configId = ?
+21:13:46.275 [nioEventLoopGroup-3-1] DEBUG c.x.d.ConfigMapper.selectConfigById - ==> Parameters: 1(Integer)
+21:13:46.277 [nioEventLoopGroup-3-1] DEBUG c.x.d.ConfigMapper.selectConfigById - <==      Total: 1
+21:13:46.771 [nioEventLoopGroup-3-1] DEBUG c.x.dao.RoleMapper.selectRoleById - ==>  Preparing: SELECT sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName, sys_role.ttsId, sys_role.userId, sys_role.state, sys_role.createTime FROM sys_role WHERE roleId = ?
+21:13:46.772 [nioEventLoopGroup-3-1] DEBUG c.x.dao.RoleMapper.selectRoleById - ==> Parameters: 3(Integer)
+21:13:46.773 [nioEventLoopGroup-3-1] DEBUG c.x.dao.RoleMapper.selectRoleById - <==      Total: 1
+21:13:46.812 [nioEventLoopGroup-3-1] DEBUG c.x.dao.MessageMapper.query_COUNT - ==>  Preparing: SELECT count(0) FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ?
+21:13:46.812 [nioEventLoopGroup-3-1] DEBUG c.x.dao.MessageMapper.query_COUNT - ==> Parameters: web_test_device(String)
+21:13:46.814 [nioEventLoopGroup-3-1] DEBUG c.x.dao.MessageMapper.query_COUNT - <==      Total: 1
+21:13:46.816 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.query - ==>  Preparing: SELECT sys_message.messageId, sys_message.message, sys_message.sender, sys_message.audioPath, sys_message.state, sys_message.createTime , sys_device.deviceId, sys_device.deviceName, sys_device.userId , sys_role.roleId, sys_role.roleName, sys_role.voiceName FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ? ORDER BY sys_message.createTime DESC LIMIT ?
+21:13:46.816 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.query - ==> Parameters: web_test_device(String), 10(Integer)
+21:13:46.820 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.query - <==      Total: 10
+21:13:46.820 [nioEventLoopGroup-3-1] INFO  c.x.w.llm.api.AbstractLlmService - 已初始化设备 web_test_device 的历史记录缓存，共 10 条消息
+21:13:46.821 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+21:13:46.822 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 97b082cc(String), user(String), 3(Integer), 你好(String), null
+21:13:46.829 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+21:13:46.850 [nioEventLoopGroup-3-1] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 97b082cc, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:13:50.474 [pool-2-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 97b082cc, Type: tts, State: start
+21:13:50.475 [pool-1-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 97b082cc, Type: tts, State: sentence_start, Text: 你好！有什么我可以帮助你的吗？
+21:13:50.480 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:13:50.481 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:13:50.486 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:13:50.494 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 97b082cc, DeviceId: web_test_device
+21:13:50.495 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:50379
+21:13:50.538 [pool-1-thread-1] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+21:13:52.332 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+21:13:52.333 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 97b082cc(String), assistant(String), 3(Integer), 你好！有什么我可以帮助你的吗？如果你有任何问题或者需要信息，随时告诉我！(String), audio/93de42ac0b004cbe932e9148c612b6a6.mp3(String)
+21:13:52.339 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+21:15:00.048 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+21:15:00.048 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x0f8c93bf, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+21:15:00.048 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x0f8c93bf, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+21:15:00.049 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.PoolThreadCache - Freed 12 thread-local buffer(s) from thread: nioEventLoopGroup-3-1
+21:15:00.051 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+21:15:00.057 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.

--- a/usr/logs/demo.2025-04-05.0.log
+++ b/usr/logs/demo.2025-04-05.0.log
@@ -624,3 +624,3563 @@ io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
 21:15:00.049 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.PoolThreadCache - Freed 12 thread-local buffer(s) from thread: nioEventLoopGroup-3-1
 21:15:00.051 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
 21:15:00.057 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+21:15:05.422 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 22400 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+21:15:05.425 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+21:15:06.509 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+21:15:06.514 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+21:15:06.516 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+21:15:06.516 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+21:15:06.634 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+21:15:06.635 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1160 ms
+21:15:07.301 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+21:15:07.305 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+21:15:07.310 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+21:15:07.310 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+21:15:07.318 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+21:15:07.325 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+21:15:07.325 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+21:15:07.331 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+21:15:07.331 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+21:15:07.332 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+21:15:07.332 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+21:15:07.333 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+21:15:07.333 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+21:15:07.334 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+21:15:07.334 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+21:15:07.334 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+21:15:07.334 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+21:15:07.334 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+21:15:07.335 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+21:15:07.335 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+21:15:07.335 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+21:15:07.336 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+21:15:07.336 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+21:15:07.337 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+21:15:07.337 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+21:15:07.338 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+21:15:07.338 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+21:15:07.339 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+21:15:07.374 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 22400 (auto-detected)
+21:15:07.375 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+21:15:07.375 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+21:15:07.685 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+21:15:07.686 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+21:15:07.703 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+21:15:07.711 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+21:15:07.711 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+21:15:07.723 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+21:15:07.730 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+21:15:07.730 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+21:15:07.731 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+21:15:07.733 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+21:15:07.745 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x84f6ca17] REGISTERED
+21:15:07.746 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x84f6ca17] BIND: 0.0.0.0/0.0.0.0:8091
+21:15:07.748 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+21:15:07.749 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x84f6ca17, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+21:15:08.213 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+21:15:08.240 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+21:15:08.251 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+21:15:08.879 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:15:08.880 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+21:15:08.880 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+21:15:08.880 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+21:15:08.880 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:15:08.893 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 3.917 seconds (JVM running for 5.022)
+21:15:08.899 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+21:15:08.899 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+21:15:08.899 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+21:15:09.934 [RMI TCP Connection(3)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+21:15:09.935 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+21:15:09.935 [RMI TCP Connection(2)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+21:15:09.936 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+21:15:09.936 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+21:15:10.083 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+21:15:14.569 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x84f6ca17, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xfc5fc4b8, L:/127.0.0.1:8091 - R:/127.0.0.1:50557]
+21:15:14.571 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x84f6ca17, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:15:14.582 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+21:15:14.582 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+21:15:14.583 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@3fc51846
+21:15:14.621 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+21:15:14.622 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+21:15:14.626 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:50557
+21:15:14.630 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+21:15:14.630 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+21:15:14.630 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+21:15:14.630 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+21:15:14.630 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+21:15:14.654 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: fc5fc4b8, DeviceId: web_test_device
+21:15:14.657 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xfc5fc4b8, L:/127.0.0.1:8091 - R:/127.0.0.1:50557] WebSocket version V13 server handshake
+21:15:14.658 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: F2aqzsJw7dvOA5E3MbDdzA==, response: 5sM9G+YgXIO2tbXlDEiMFy43L/0=
+21:15:14.678 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x84f6ca17, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x6957fa8c, L:/127.0.0.1:8091 - R:/127.0.0.1:50558]
+21:15:14.679 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x84f6ca17, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:15:14.682 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:50558
+21:15:14.683 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 6957fa8c, DeviceId: web_test_device
+21:15:14.683 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x6957fa8c, L:/127.0.0.1:8091 - R:/127.0.0.1:50558] WebSocket version V13 server handshake
+21:15:14.683 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: yOz/Vzk45D5wTn019DOklA==, response: +vfglvp7eoHpsh3rDZgLQDD09Gg=
+21:15:14.727 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:15:14.744 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:15:14.763 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:15:14.774 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:15:14.774 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:15:14.777 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:15:14.782 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 6957fa8c, DeviceId: web_test_device
+21:15:14.783 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:15:14.790 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 6957fa8c
+21:15:14.790 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:15:14.799 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 6957fa8c, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:15:17.882 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:15:17.883 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:15:17.887 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:15:17.889 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:15:17.889 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:15:17.894 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:15:17.899 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 6957fa8c, DeviceId: web_test_device
+21:15:17.900 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"detect","text":"你好"}
+21:15:17.900 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 6957fa8c, State: detect, Mode: manual
+21:15:17.900 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 检测到唤醒词: 你好
+21:15:17.900 [nioEventLoopGroup-3-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 6957fa8c, Type: stt, State: start, Text: 你好
+21:15:17.905 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==>  Preparing: SELECT sys_config.configId, sys_config.userId, sys_config.configName, sys_config.configDesc, sys_config.configType, sys_config.provider, sys_config.appId, sys_config.apiKey, sys_config.apiSecret, sys_config.apiUrl, sys_config.isDefault, sys_config.state, sys_config.createTime FROM sys_config WHERE sys_config.configId = ?
+21:15:17.906 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==> Parameters: 1(Integer)
+21:15:17.908 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - <==      Total: 1
+21:15:18.407 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==>  Preparing: SELECT sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName, sys_role.ttsId, sys_role.userId, sys_role.state, sys_role.createTime FROM sys_role WHERE roleId = ?
+21:15:18.407 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==> Parameters: 3(Integer)
+21:15:18.408 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - <==      Total: 1
+21:15:18.447 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==>  Preparing: SELECT count(0) FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ?
+21:15:18.448 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==> Parameters: web_test_device(String)
+21:15:18.455 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - <==      Total: 1
+21:15:18.457 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==>  Preparing: SELECT sys_message.messageId, sys_message.message, sys_message.sender, sys_message.audioPath, sys_message.state, sys_message.createTime , sys_device.deviceId, sys_device.deviceName, sys_device.userId , sys_role.roleId, sys_role.roleName, sys_role.voiceName FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ? ORDER BY sys_message.createTime DESC LIMIT ?
+21:15:18.458 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==> Parameters: web_test_device(String), 10(Integer)
+21:15:18.462 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - <==      Total: 10
+21:15:18.462 [nioEventLoopGroup-3-2] INFO  c.x.w.llm.api.AbstractLlmService - 已初始化设备 web_test_device 的历史记录缓存，共 10 条消息
+21:15:18.463 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+21:15:18.464 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 6957fa8c(String), user(String), 3(Integer), 你好(String), null
+21:15:18.466 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+21:15:18.487 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 6957fa8c, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:15:21.755 [pool-2-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 6957fa8c, Type: tts, State: start
+21:15:21.756 [pool-1-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 6957fa8c, Type: tts, State: sentence_start, Text: 你好！如果你需要帮助或有任何问题，
+21:15:21.826 [pool-1-thread-1] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+21:15:23.249 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+21:15:23.250 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 6957fa8c(String), assistant(String), 3(Integer), 你好！如果你需要帮助或有任何问题，请随时告诉我，我会尽力为你提供帮助。(String), audio/83321651f4714129ad396dc860decf31.mp3(String)
+21:15:23.253 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+21:20:14.663 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: fc5fc4b8
+21:25:14.679 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: fc5fc4b8
+21:30:14.710 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: fc5fc4b8
+21:35:14.736 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: fc5fc4b8
+21:35:23.619 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+21:35:23.619 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x84f6ca17, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+21:35:23.619 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x84f6ca17, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+21:35:23.620 [nioEventLoopGroup-3-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 12 thread-local buffer(s) from thread: nioEventLoopGroup-3-2
+21:35:23.622 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+21:35:23.626 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+21:36:19.323 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 19104 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+21:36:19.326 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+21:36:20.413 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+21:36:20.419 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+21:36:20.421 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+21:36:20.421 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+21:36:20.536 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+21:36:20.536 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1157 ms
+21:36:21.227 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+21:36:21.232 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+21:36:21.236 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+21:36:21.237 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+21:36:21.244 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+21:36:21.251 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+21:36:21.251 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+21:36:21.257 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+21:36:21.257 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+21:36:21.258 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+21:36:21.258 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+21:36:21.259 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+21:36:21.259 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+21:36:21.259 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+21:36:21.260 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+21:36:21.260 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+21:36:21.260 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+21:36:21.260 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+21:36:21.261 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+21:36:21.261 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+21:36:21.261 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+21:36:21.262 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+21:36:21.262 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+21:36:21.263 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+21:36:21.263 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+21:36:21.263 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+21:36:21.263 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+21:36:21.265 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+21:36:21.299 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 19104 (auto-detected)
+21:36:21.300 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+21:36:21.300 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+21:36:21.604 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+21:36:21.605 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+21:36:21.622 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+21:36:21.630 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+21:36:21.630 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+21:36:21.641 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+21:36:21.648 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+21:36:21.648 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+21:36:21.648 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+21:36:21.649 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+21:36:21.661 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8] REGISTERED
+21:36:21.662 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8] BIND: 0.0.0.0/0.0.0.0:8091
+21:36:21.664 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+21:36:21.665 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+21:36:22.075 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+21:36:22.099 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+21:36:22.109 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+21:36:22.717 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:36:22.717 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+21:36:22.717 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+21:36:22.717 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+21:36:22.717 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:36:22.730 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 3.911 seconds (JVM running for 4.931)
+21:36:22.734 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+21:36:22.734 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+21:36:22.734 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+21:36:23.818 [RMI TCP Connection(3)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+21:36:23.818 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+21:36:23.819 [RMI TCP Connection(2)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+21:36:23.819 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+21:36:23.820 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 0 ms
+21:36:23.941 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+21:36:32.241 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x447e8dbc, L:/127.0.0.1:8091 - R:/127.0.0.1:51780]
+21:36:32.241 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:36:32.252 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+21:36:32.252 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+21:36:32.253 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@3aed16ab
+21:36:32.280 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+21:36:32.280 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+21:36:32.283 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:51780
+21:36:32.287 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+21:36:32.287 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+21:36:32.287 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+21:36:32.287 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+21:36:32.287 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+21:36:32.307 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 447e8dbc, DeviceId: web_test_device
+21:36:32.309 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x447e8dbc, L:/127.0.0.1:8091 - R:/127.0.0.1:51780] WebSocket version V13 server handshake
+21:36:32.310 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: 7ZTt11iuVbzeaSPiyuaocA==, response: PN/Q/q4J0XHq/LvMy+LYMQh7L50=
+21:36:32.354 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:36:32.368 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:36:32.383 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:36:32.393 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:36:32.393 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:36:32.395 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:36:32.400 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 447e8dbc, DeviceId: web_test_device
+21:36:32.401 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:36:32.407 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 447e8dbc
+21:36:32.408 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:36:32.416 [nioEventLoopGroup-3-1] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 447e8dbc, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:36:32.417 [nioEventLoopGroup-3-1] WARN  c.x.w.h.WebSocketExceptionHandler - 关闭异常连接 - SessionId: 447e8dbc
+21:36:32.424 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:36:32.424 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:36:32.426 [nioEventLoopGroup-3-1] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:36:32.431 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 447e8dbc, DeviceId: web_test_device
+21:36:32.431 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:51780
+21:36:38.484 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x21bd5b63, L:/127.0.0.1:8091 - R:/127.0.0.1:51783]
+21:36:38.485 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:36:38.491 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:51783
+21:36:38.492 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 21bd5b63, DeviceId: web_test_device
+21:36:38.492 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x21bd5b63, L:/127.0.0.1:8091 - R:/127.0.0.1:51783] WebSocket version V13 server handshake
+21:36:38.493 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: 5Qa8cDXYgdwNEX2zxqPDHg==, response: KS8QMuXp/P8yRww+5t2HtVr7f0c=
+21:36:38.516 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x1c520a8e, L:/127.0.0.1:8091 - R:/127.0.0.1:51784]
+21:36:38.516 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:36:38.519 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:51784
+21:36:38.521 [nioEventLoopGroup-3-3] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 1c520a8e, DeviceId: web_test_device
+21:36:38.521 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x1c520a8e, L:/127.0.0.1:8091 - R:/127.0.0.1:51784] WebSocket version V13 server handshake
+21:36:38.521 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: MuRwdhvOryvhjOMEV4ayqQ==, response: xHl25O5QzzmJh6dtcP/Xbq7N7ew=
+21:36:38.526 [nioEventLoopGroup-3-3] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:36:38.526 [nioEventLoopGroup-3-3] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:36:38.529 [nioEventLoopGroup-3-3] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:36:38.530 [nioEventLoopGroup-3-3] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:36:38.530 [nioEventLoopGroup-3-3] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:36:38.536 [nioEventLoopGroup-3-3] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:36:38.542 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 1c520a8e, DeviceId: web_test_device
+21:36:38.542 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:36:38.542 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 1c520a8e
+21:36:38.542 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:36:38.543 [nioEventLoopGroup-3-3] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 1c520a8e, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:36:38.543 [nioEventLoopGroup-3-3] WARN  c.x.w.h.WebSocketExceptionHandler - 关闭异常连接 - SessionId: 1c520a8e
+21:36:38.546 [nioEventLoopGroup-3-3] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:36:38.547 [nioEventLoopGroup-3-3] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:36:38.549 [nioEventLoopGroup-3-3] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:36:38.553 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 1c520a8e, DeviceId: web_test_device
+21:36:38.553 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:51784
+21:39:40.861 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+21:39:40.861 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+21:39:40.862 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x247ac5b8, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+21:39:40.862 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:51783
+21:39:40.863 [nioEventLoopGroup-3-3] DEBUG io.netty.buffer.PoolThreadCache - Freed 5 thread-local buffer(s) from thread: nioEventLoopGroup-3-3
+21:39:40.863 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.PoolThreadCache - Freed 5 thread-local buffer(s) from thread: nioEventLoopGroup-3-1
+21:39:40.865 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+21:39:40.870 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+21:39:46.212 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 29636 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+21:39:46.215 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+21:39:47.312 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+21:39:47.318 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+21:39:47.320 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+21:39:47.320 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+21:39:47.442 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+21:39:47.442 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1178 ms
+21:39:48.160 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+21:39:48.165 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+21:39:48.169 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+21:39:48.170 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+21:39:48.178 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+21:39:48.186 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+21:39:48.186 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+21:39:48.192 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+21:39:48.193 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+21:39:48.193 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+21:39:48.194 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+21:39:48.195 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+21:39:48.196 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+21:39:48.196 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+21:39:48.197 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+21:39:48.197 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+21:39:48.197 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+21:39:48.197 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+21:39:48.197 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+21:39:48.197 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+21:39:48.198 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+21:39:48.199 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+21:39:48.199 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+21:39:48.200 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+21:39:48.200 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+21:39:48.200 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+21:39:48.200 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+21:39:48.202 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+21:39:48.239 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 29636 (auto-detected)
+21:39:48.240 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+21:39:48.240 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+21:39:48.552 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+21:39:48.553 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+21:39:48.569 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+21:39:48.577 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+21:39:48.577 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+21:39:48.588 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+21:39:48.588 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+21:39:48.588 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+21:39:48.588 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+21:39:48.588 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+21:39:48.588 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+21:39:48.588 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+21:39:48.588 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+21:39:48.588 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+21:39:48.588 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+21:39:48.589 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+21:39:48.589 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+21:39:48.595 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+21:39:48.595 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+21:39:48.597 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+21:39:48.598 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+21:39:48.612 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5] REGISTERED
+21:39:48.613 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5] BIND: 0.0.0.0/0.0.0.0:8091
+21:39:48.614 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+21:39:48.616 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+21:39:49.036 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+21:39:49.061 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+21:39:49.073 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+21:39:49.686 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:39:49.686 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+21:39:49.686 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+21:39:49.686 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+21:39:49.686 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:39:49.699 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 3.941 seconds (JVM running for 5.037)
+21:39:49.706 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+21:39:49.706 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+21:39:49.706 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+21:39:50.365 [RMI TCP Connection(1)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+21:39:50.366 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+21:39:50.367 [RMI TCP Connection(2)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+21:39:50.367 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+21:39:50.368 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
+21:39:50.520 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+21:39:55.560 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x01635bcb, L:/127.0.0.1:8091 - R:/127.0.0.1:51961]
+21:39:55.560 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:39:55.570 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+21:39:55.570 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+21:39:55.571 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@2438b77a
+21:39:55.599 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+21:39:55.599 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+21:39:55.602 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:51961
+21:39:55.605 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+21:39:55.605 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+21:39:55.605 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+21:39:55.605 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+21:39:55.606 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+21:39:55.625 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 01635bcb, DeviceId: web_test_device
+21:39:55.627 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x01635bcb, L:/127.0.0.1:8091 - R:/127.0.0.1:51961] WebSocket version V13 server handshake
+21:39:55.628 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: CoNga7oiBaQJ2iwEQowt6A==, response: mXq9FGsvozObNCRepVoazx1M16g=
+21:39:55.661 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xdaf0ccb1, L:/127.0.0.1:8091 - R:/127.0.0.1:51963]
+21:39:55.662 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:39:55.665 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:51963
+21:39:55.666 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: daf0ccb1, DeviceId: web_test_device
+21:39:55.666 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xdaf0ccb1, L:/127.0.0.1:8091 - R:/127.0.0.1:51963] WebSocket version V13 server handshake
+21:39:55.666 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: hfCp0DysWdECCC5T1ljoOw==, response: SOiFJboO+9ZrHckf+A0WfXAJij0=
+21:39:55.708 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:39:55.728 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:39:55.743 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:39:55.752 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:39:55.752 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:39:55.754 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:39:55.760 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: daf0ccb1, DeviceId: web_test_device
+21:39:55.760 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:39:55.766 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: daf0ccb1
+21:39:55.766 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:39:55.778 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: daf0ccb1, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:39:55.780 [nioEventLoopGroup-3-2] WARN  c.x.w.h.WebSocketExceptionHandler - 关闭异常连接 - SessionId: daf0ccb1
+21:39:55.784 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:39:55.784 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:39:55.787 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:39:55.792 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: daf0ccb1, DeviceId: web_test_device
+21:39:55.792 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:51963
+21:44:55.633 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 01635bcb
+21:48:40.830 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xb782bf59, L:/127.0.0.1:8091 - R:/127.0.0.1:52409]
+21:48:40.831 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:48:40.839 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52409
+21:48:40.840 [nioEventLoopGroup-3-3] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: b782bf59, DeviceId: web_test_device
+21:48:40.840 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xb782bf59, L:/127.0.0.1:8091 - R:/127.0.0.1:52409] WebSocket version V13 server handshake
+21:48:40.840 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: wuMVTye6q8jXAhT57XFtDw==, response: g/1+Wg/uOPa1abyaNh8Kh+ObSpg=
+21:48:40.861 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x52b71c61, L:/127.0.0.1:8091 - R:/127.0.0.1:52410]
+21:48:40.861 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:48:40.864 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52410
+21:48:40.864 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 52b71c61, DeviceId: web_test_device
+21:48:40.865 [nioEventLoopGroup-3-4] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x52b71c61, L:/127.0.0.1:8091 - R:/127.0.0.1:52410] WebSocket version V13 server handshake
+21:48:40.865 [nioEventLoopGroup-3-4] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: V7GIfgaLiPFc/rV5UHLSjg==, response: BDLZ2q14yLgFyv5MY1O0iphC8Fc=
+21:48:40.871 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:48:40.871 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:48:40.873 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:48:40.875 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:48:40.875 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:48:40.878 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:48:40.885 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 52b71c61, DeviceId: web_test_device
+21:48:40.885 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:48:40.885 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 52b71c61
+21:48:40.885 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:49:58.355 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 01635bcb
+21:50:24.870 [nioEventLoopGroup-3-4] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 52b71c61, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:50:24.870 [nioEventLoopGroup-3-4] WARN  c.x.w.h.WebSocketExceptionHandler - 关闭异常连接 - SessionId: 52b71c61
+21:50:24.878 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:50:24.878 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:50:24.882 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:50:24.886 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 52b71c61, DeviceId: web_test_device
+21:50:24.887 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52410
+21:51:11.975 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xb4689a69, L:/127.0.0.1:8091 - R:/127.0.0.1:52535]
+21:51:11.976 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:51:11.978 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52535
+21:51:11.979 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: b4689a69, DeviceId: web_test_device
+21:51:11.979 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xb4689a69, L:/127.0.0.1:8091 - R:/127.0.0.1:52535] WebSocket version V13 server handshake
+21:51:11.980 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: 2D9FLSodCf6H6i1SrGIaJQ==, response: jXVeVvUQWiXJlmAFpmKn+Kv6A70=
+21:51:12.006 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x8665154a, L:/127.0.0.1:8091 - R:/127.0.0.1:52536]
+21:51:12.007 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:51:12.008 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52536
+21:51:12.008 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 8665154a, DeviceId: web_test_device
+21:51:12.008 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x8665154a, L:/127.0.0.1:8091 - R:/127.0.0.1:52536] WebSocket version V13 server handshake
+21:51:12.008 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: 02/D+UP/Y1zTPM/NAzR11w==, response: vFJ9l0ws+r3Q0c+JBLpVALrfibY=
+21:51:12.013 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:51:12.013 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:51:12.019 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:51:12.021 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:51:12.022 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:51:12.025 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:51:12.029 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 8665154a, DeviceId: web_test_device
+21:51:12.029 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:51:12.029 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 8665154a
+21:51:12.029 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:51:12.030 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 8665154a, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:51:12.030 [nioEventLoopGroup-3-2] WARN  c.x.w.h.WebSocketExceptionHandler - 关闭异常连接 - SessionId: 8665154a
+21:51:12.032 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:51:12.032 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:51:12.034 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:51:12.038 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 8665154a, DeviceId: web_test_device
+21:51:12.038 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52536
+21:53:17.085 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+21:53:17.085 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+21:53:17.085 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8b880bf5, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+21:53:17.086 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52409
+21:53:17.086 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52535
+21:53:17.086 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:51961
+21:53:17.086 [nioEventLoopGroup-3-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 5 thread-local buffer(s) from thread: nioEventLoopGroup-3-2
+21:53:17.087 [nioEventLoopGroup-3-4] DEBUG io.netty.buffer.PoolThreadCache - Freed 5 thread-local buffer(s) from thread: nioEventLoopGroup-3-4
+21:53:17.089 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+21:53:17.110 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+21:53:28.136 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 12888 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+21:53:28.139 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+21:53:29.856 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+21:53:29.865 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+21:53:29.866 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+21:53:29.867 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+21:53:29.986 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+21:53:29.986 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1453 ms
+21:53:30.661 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+21:53:30.666 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+21:53:30.671 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+21:53:30.671 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+21:53:30.679 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+21:53:30.686 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+21:53:30.686 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+21:53:30.692 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+21:53:30.692 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+21:53:30.693 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+21:53:30.693 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+21:53:30.693 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+21:53:30.694 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+21:53:30.694 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+21:53:30.695 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+21:53:30.695 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+21:53:30.695 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+21:53:30.695 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+21:53:30.695 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+21:53:30.695 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+21:53:30.695 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+21:53:30.696 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+21:53:30.697 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+21:53:30.697 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+21:53:30.697 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+21:53:30.698 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+21:53:30.698 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+21:53:30.700 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+21:53:30.735 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 12888 (auto-detected)
+21:53:30.736 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+21:53:30.736 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+21:53:31.044 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+21:53:31.046 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+21:53:31.062 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+21:53:31.070 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+21:53:31.070 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+21:53:31.081 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+21:53:31.081 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+21:53:31.082 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+21:53:31.082 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+21:53:31.082 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+21:53:31.082 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+21:53:31.082 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+21:53:31.082 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+21:53:31.082 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+21:53:31.082 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+21:53:31.082 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+21:53:31.082 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+21:53:31.088 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+21:53:31.089 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+21:53:31.090 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+21:53:31.092 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+21:53:31.103 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2] REGISTERED
+21:53:31.104 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2] BIND: 0.0.0.0/0.0.0.0:8091
+21:53:31.106 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+21:53:31.107 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+21:53:31.555 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+21:53:31.580 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+21:53:31.590 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+21:53:32.228 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:53:32.229 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+21:53:32.229 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+21:53:32.229 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+21:53:32.229 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:53:32.241 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.743 seconds (JVM running for 6.151)
+21:53:32.246 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+21:53:32.246 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+21:53:32.246 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+21:53:32.307 [RMI TCP Connection(1)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+21:53:32.307 [RMI TCP Connection(1)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+21:53:32.469 [RMI TCP Connection(1)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+21:53:33.193 [RMI TCP Connection(3)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+21:53:33.193 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+21:53:33.194 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+21:53:42.418 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x30c09e70, L:/127.0.0.1:8091 - R:/127.0.0.1:52696]
+21:53:42.419 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:53:42.428 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+21:53:42.428 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+21:53:42.429 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@3370a52f
+21:53:42.456 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+21:53:42.456 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+21:53:42.459 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52696
+21:53:42.462 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+21:53:42.463 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+21:53:42.463 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+21:53:42.463 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+21:53:42.463 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+21:53:42.482 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 30c09e70, DeviceId: web_test_device
+21:53:42.484 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x30c09e70, L:/127.0.0.1:8091 - R:/127.0.0.1:52696] WebSocket version V13 server handshake
+21:53:42.486 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: WccMr/XbrK1SqVxkr7wU5g==, response: K4U+lJs9C+yetu7gGhbxDqvFE6Q=
+21:53:42.518 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xb6858cd2, L:/127.0.0.1:8091 - R:/127.0.0.1:52697]
+21:53:42.518 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:53:42.521 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52697
+21:53:42.522 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: b6858cd2, DeviceId: web_test_device
+21:53:42.522 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xb6858cd2, L:/127.0.0.1:8091 - R:/127.0.0.1:52697] WebSocket version V13 server handshake
+21:53:42.522 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: bjtHmt4kHJfJHy1mKGjMdg==, response: p1wi3v7yiG9n1YbJCL0pK7BoCbU=
+21:53:42.528 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+21:53:42.565 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:53:42.580 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:53:42.596 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:53:42.604 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:53:42.604 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:53:42.607 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:53:42.612 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: b6858cd2, DeviceId: web_test_device
+21:53:42.612 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:53:42.618 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: b6858cd2
+21:53:42.619 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:53:42.629 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: b6858cd2, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:53:42.635 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:53:42.636 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:53:42.638 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:53:42.642 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: b6858cd2, DeviceId: web_test_device
+21:53:42.642 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52697
+21:54:13.540 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x13928cda, L:/127.0.0.1:8091 - R:/127.0.0.1:52735]
+21:54:13.540 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:54:13.544 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52735
+21:54:13.545 [nioEventLoopGroup-3-3] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 13928cda, DeviceId: web_test_device
+21:54:13.545 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x13928cda, L:/127.0.0.1:8091 - R:/127.0.0.1:52735] WebSocket version V13 server handshake
+21:54:13.545 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: OHGXvEv++7KsadM7PBPLig==, response: diCHjEH6W7WOKmiiz7yPAK4SSYc=
+21:54:13.567 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x010c719a, L:/127.0.0.1:8091 - R:/127.0.0.1:52736]
+21:54:13.567 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:54:13.570 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52736
+21:54:13.570 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 010c719a, DeviceId: web_test_device
+21:54:13.570 [nioEventLoopGroup-3-4] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x010c719a, L:/127.0.0.1:8091 - R:/127.0.0.1:52736] WebSocket version V13 server handshake
+21:54:13.571 [nioEventLoopGroup-3-4] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: Nl5wg7cQEjdv7Jiw+zXWuA==, response: CXCUo6oeoGqO/bXD5BCviElA1GA=
+21:54:13.575 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+21:54:13.576 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:54:13.577 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:54:13.584 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:54:13.586 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:54:13.587 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:54:13.589 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:54:13.593 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 010c719a, DeviceId: web_test_device
+21:54:13.593 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:54:13.593 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 010c719a
+21:54:13.593 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:54:40.602 [nioEventLoopGroup-3-4] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 010c719a, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:54:40.605 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:54:40.605 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:54:40.611 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:54:40.615 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 010c719a, DeviceId: web_test_device
+21:54:40.616 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52736
+21:55:05.585 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x530913f7, L:/127.0.0.1:8091 - R:/127.0.0.1:52787]
+21:55:05.586 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:55:05.587 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52787
+21:55:05.588 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 530913f7, DeviceId: web_test_device
+21:55:05.588 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x530913f7, L:/127.0.0.1:8091 - R:/127.0.0.1:52787] WebSocket version V13 server handshake
+21:55:05.588 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: hJ6YtkobBMC9N8NyLd2olQ==, response: AsX/ALPYqEF1IXQGECjV6M5udII=
+21:55:05.613 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xef851e09, L:/127.0.0.1:8091 - R:/127.0.0.1:52788]
+21:55:05.614 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:55:05.615 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52788
+21:55:05.615 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: ef851e09, DeviceId: web_test_device
+21:55:05.616 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xef851e09, L:/127.0.0.1:8091 - R:/127.0.0.1:52788] WebSocket version V13 server handshake
+21:55:05.616 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: 3pRQ6YjGXdvg5P/rSQgHTA==, response: ySSQ5sAaLmdqnqZjH7hNGt8UApc=
+21:55:05.619 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+21:55:05.621 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:55:05.622 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:55:05.624 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:55:05.625 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:55:05.625 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:55:05.631 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:55:05.635 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: ef851e09, DeviceId: web_test_device
+21:55:05.635 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:55:05.635 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: ef851e09
+21:55:05.635 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:55:25.428 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: ef851e09, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:55:25.432 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:55:25.432 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:55:25.438 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:55:25.443 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: ef851e09, DeviceId: web_test_device
+21:55:25.443 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52788
+21:56:00.168 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+21:56:00.168 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+21:56:00.168 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52735
+21:56:00.168 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52787
+21:56:00.168 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x53cfbca2, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+21:56:00.168 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52696
+21:56:00.170 [nioEventLoopGroup-3-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 6 thread-local buffer(s) from thread: nioEventLoopGroup-3-2
+21:56:00.170 [nioEventLoopGroup-3-4] DEBUG io.netty.buffer.PoolThreadCache - Freed 6 thread-local buffer(s) from thread: nioEventLoopGroup-3-4
+21:56:00.172 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+21:56:00.176 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+21:56:07.444 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 22220 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+21:56:07.446 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+21:56:08.489 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+21:56:08.496 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+21:56:08.497 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+21:56:08.497 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+21:56:08.633 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+21:56:08.633 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1139 ms
+21:56:09.347 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+21:56:09.352 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+21:56:09.357 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+21:56:09.357 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+21:56:09.366 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+21:56:09.373 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+21:56:09.373 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+21:56:09.379 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+21:56:09.380 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+21:56:09.380 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+21:56:09.381 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+21:56:09.381 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+21:56:09.382 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+21:56:09.382 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+21:56:09.383 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+21:56:09.383 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+21:56:09.383 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+21:56:09.383 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+21:56:09.383 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+21:56:09.383 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+21:56:09.384 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+21:56:09.385 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+21:56:09.385 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+21:56:09.385 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+21:56:09.385 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+21:56:09.386 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+21:56:09.386 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+21:56:09.387 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+21:56:09.422 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 22220 (auto-detected)
+21:56:09.423 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+21:56:09.423 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+21:56:09.751 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+21:56:09.752 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+21:56:09.769 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+21:56:09.778 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+21:56:09.778 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+21:56:09.790 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+21:56:09.790 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+21:56:09.790 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+21:56:09.790 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+21:56:09.790 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+21:56:09.790 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+21:56:09.790 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+21:56:09.790 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+21:56:09.790 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+21:56:09.791 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+21:56:09.791 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+21:56:09.791 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+21:56:09.799 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+21:56:09.799 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+21:56:09.801 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+21:56:09.802 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+21:56:09.815 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x19701382] REGISTERED
+21:56:09.816 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x19701382] BIND: 0.0.0.0/0.0.0.0:8091
+21:56:09.817 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+21:56:09.818 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x19701382, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+21:56:10.282 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+21:56:10.309 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+21:56:10.321 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+21:56:10.992 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:56:10.993 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+21:56:10.993 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+21:56:10.993 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+21:56:10.993 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:56:11.014 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.011 seconds (JVM running for 5.302)
+21:56:11.022 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+21:56:11.022 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+21:56:11.022 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+21:56:12.128 [RMI TCP Connection(4)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+21:56:12.129 [RMI TCP Connection(4)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+21:56:12.129 [RMI TCP Connection(3)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+21:56:12.129 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+21:56:12.131 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
+21:56:12.287 [RMI TCP Connection(4)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+21:56:14.355 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x19701382, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x4c71f1f6, L:/127.0.0.1:8091 - R:/127.0.0.1:52883]
+21:56:14.356 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x19701382, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:56:14.366 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+21:56:14.366 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+21:56:14.367 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@1a22b817
+21:56:14.397 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+21:56:14.397 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+21:56:14.400 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52883
+21:56:14.404 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+21:56:14.404 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+21:56:14.404 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+21:56:14.404 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+21:56:14.404 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+21:56:14.425 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 4c71f1f6, DeviceId: web_test_device
+21:56:14.428 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x4c71f1f6, L:/127.0.0.1:8091 - R:/127.0.0.1:52883] WebSocket version V13 server handshake
+21:56:14.429 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: 8nAnRMC78H0VQWlZfkGd8A==, response: XuHgLKnx/CtREVGoHzGS+D3boRo=
+21:56:14.460 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x19701382, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x0afd3b49, L:/127.0.0.1:8091 - R:/127.0.0.1:52884]
+21:56:14.461 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x19701382, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:56:14.465 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:52884
+21:56:14.466 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 0afd3b49, DeviceId: web_test_device
+21:56:14.466 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x0afd3b49, L:/127.0.0.1:8091 - R:/127.0.0.1:52884] WebSocket version V13 server handshake
+21:56:14.466 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: Y6qcoRkI7AzQRtQorBbbVQ==, response: Jr8le3phkPQ+TWpYX1ZocddpwB0=
+21:56:14.472 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+21:56:14.513 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:56:14.542 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:56:14.565 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:56:14.574 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:56:14.574 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:56:14.577 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:56:14.582 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 0afd3b49, DeviceId: web_test_device
+21:56:14.582 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:56:14.588 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 0afd3b49, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:56:14.593 [nioEventLoopGroup-3-2] WARN  c.x.w.h.TextWebSocketFrameHandler - 不支持的传输方式: 
+21:56:14.598 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 0afd3b49, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:56:14.600 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - 发送关闭帧失败
+java.nio.channels.ClosedChannelException: null
+	at io.netty.handler.codec.http.websocketx.WebSocketProtocolHandler.write(WebSocketProtocolHandler.java:113)
+	at io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.write(WebSocketServerProtocolHandler.java:54)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
+	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
+	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
+	at io.netty.handler.timeout.IdleStateHandler.write(IdleStateHandler.java:302)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:879)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:940)
+	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:966)
+	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:934)
+	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:984)
+	at com.xiaozhi.websocket.handler.WebSocketExceptionHandler.exceptionCaught(WebSocketExceptionHandler.java:37)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:346)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:325)
+	at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:317)
+	at io.netty.channel.ChannelInboundHandlerAdapter.exceptionCaught(ChannelInboundHandlerAdapter.java:143)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:346)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:447)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:56:14.602 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:56:14.602 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:56:14.604 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:56:14.608 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 0afd3b49, DeviceId: web_test_device
+21:56:14.608 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52884
+21:57:43.411 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+21:57:43.412 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x19701382, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+21:57:43.412 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:52883
+21:57:43.412 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x19701382, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+21:57:43.413 [nioEventLoopGroup-3-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 4 thread-local buffer(s) from thread: nioEventLoopGroup-3-2
+21:57:43.414 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+21:57:43.422 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+21:57:48.672 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 25908 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+21:57:48.675 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+21:57:49.742 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+21:57:49.749 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+21:57:49.750 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+21:57:49.750 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+21:57:49.903 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+21:57:49.903 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1175 ms
+21:57:50.668 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+21:57:50.673 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+21:57:50.677 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+21:57:50.678 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+21:57:50.687 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+21:57:50.693 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+21:57:50.693 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+21:57:50.700 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+21:57:50.700 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+21:57:50.701 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+21:57:50.701 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+21:57:50.702 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+21:57:50.702 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+21:57:50.702 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+21:57:50.703 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+21:57:50.703 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+21:57:50.703 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+21:57:50.703 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+21:57:50.703 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+21:57:50.703 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+21:57:50.704 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+21:57:50.705 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+21:57:50.705 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+21:57:50.706 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+21:57:50.706 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+21:57:50.706 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+21:57:50.706 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+21:57:50.707 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+21:57:50.743 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 25908 (auto-detected)
+21:57:50.744 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+21:57:50.744 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+21:57:51.068 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+21:57:51.069 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+21:57:51.088 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+21:57:51.096 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+21:57:51.096 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+21:57:51.107 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+21:57:51.116 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+21:57:51.116 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+21:57:51.117 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+21:57:51.118 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+21:57:51.131 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x5638e94a] REGISTERED
+21:57:51.132 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x5638e94a] BIND: 0.0.0.0/0.0.0.0:8091
+21:57:51.133 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+21:57:51.134 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x5638e94a, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+21:57:51.632 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+21:57:51.661 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+21:57:51.672 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+21:57:52.358 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:57:52.358 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+21:57:52.358 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+21:57:52.358 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+21:57:52.358 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:57:52.371 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.147 seconds (JVM running for 5.368)
+21:57:52.378 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+21:57:52.378 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+21:57:52.378 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+21:57:52.883 [RMI TCP Connection(5)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+21:57:52.884 [RMI TCP Connection(5)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+21:57:52.884 [RMI TCP Connection(6)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+21:57:52.884 [RMI TCP Connection(6)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+21:57:52.885 [RMI TCP Connection(5)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+21:57:53.026 [RMI TCP Connection(6)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+21:58:06.180 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+21:58:06.183 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+21:58:06.216 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x5638e94a, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+21:58:06.216 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x5638e94a, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+21:58:06.303 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+21:58:11.928 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 12144 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+21:58:11.931 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+21:58:13.079 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+21:58:13.086 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+21:58:13.088 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+21:58:13.088 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+21:58:13.219 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+21:58:13.219 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1230 ms
+21:58:13.907 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+21:58:13.912 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+21:58:13.916 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+21:58:13.917 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+21:58:13.925 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+21:58:13.931 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+21:58:13.931 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+21:58:13.937 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+21:58:13.937 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+21:58:13.938 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+21:58:13.939 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+21:58:13.939 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+21:58:13.940 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+21:58:13.940 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+21:58:13.941 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+21:58:13.941 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+21:58:13.941 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+21:58:13.941 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+21:58:13.941 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+21:58:13.941 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+21:58:13.942 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+21:58:13.942 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+21:58:13.942 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+21:58:13.943 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+21:58:13.943 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+21:58:13.944 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+21:58:13.944 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+21:58:13.945 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+21:58:13.982 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 12144 (auto-detected)
+21:58:13.983 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+21:58:13.983 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+21:58:14.301 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+21:58:14.301 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+21:58:14.319 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+21:58:14.327 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+21:58:14.327 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+21:58:14.339 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+21:58:14.346 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+21:58:14.346 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+21:58:14.348 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+21:58:14.349 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+21:58:14.362 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6] REGISTERED
+21:58:14.363 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6] BIND: 0.0.0.0/0.0.0.0:8091
+21:58:14.365 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+21:58:14.366 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+21:58:14.821 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+21:58:14.861 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+21:58:14.878 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+21:58:15.789 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:58:15.789 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+21:58:15.789 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+21:58:15.789 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+21:58:15.790 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+21:58:15.808 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.401 seconds (JVM running for 5.497)
+21:58:15.816 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+21:58:15.816 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+21:58:15.816 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+21:58:17.007 [RMI TCP Connection(4)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+21:58:17.007 [RMI TCP Connection(4)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+21:58:17.007 [RMI TCP Connection(5)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+21:58:17.007 [RMI TCP Connection(5)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+21:58:17.008 [RMI TCP Connection(4)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+21:58:17.129 [RMI TCP Connection(5)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+21:58:20.903 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x48f03bbe, L:/127.0.0.1:8091 - R:/127.0.0.1:53142]
+21:58:20.904 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:58:20.913 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+21:58:20.913 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+21:58:20.914 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@47eb5781
+21:58:20.942 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+21:58:20.942 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+21:58:20.946 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:53142
+21:58:20.949 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+21:58:20.949 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+21:58:20.949 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+21:58:20.949 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+21:58:20.949 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+21:58:20.969 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 48f03bbe, DeviceId: web_test_device
+21:58:20.972 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x48f03bbe, L:/127.0.0.1:8091 - R:/127.0.0.1:53142] WebSocket version V13 server handshake
+21:58:20.973 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: NRhSynDOSwyQPzbqi0gQfQ==, response: yyHC4cbOOn8RwYEp0CmCJlBQC3c=
+21:58:21.001 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xff20b4c9, L:/127.0.0.1:8091 - R:/127.0.0.1:53143]
+21:58:21.001 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+21:58:21.005 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:53143
+21:58:21.006 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: ff20b4c9, DeviceId: web_test_device
+21:58:21.006 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xff20b4c9, L:/127.0.0.1:8091 - R:/127.0.0.1:53143] WebSocket version V13 server handshake
+21:58:21.006 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: fAgWuvq5XaG2x/ZVyfNoBg==, response: o8DS3YVoqudTsL8st8SecXYd7PI=
+21:58:21.012 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+21:58:21.048 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+21:58:21.063 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+21:58:21.077 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+21:58:21.085 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:58:21.086 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+21:58:21.087 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:58:21.093 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: ff20b4c9, DeviceId: web_test_device
+21:58:21.094 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:58:21.107 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: ff20b4c9, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+21:58:56.747 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+21:59:54.914 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: ff20b4c9, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+21:59:54.920 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+21:59:54.920 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+21:59:54.925 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+21:59:54.929 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: ff20b4c9, DeviceId: web_test_device
+21:59:54.929 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:53143
+22:00:47.641 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x01f86e11, L:/127.0.0.1:8091 - R:/127.0.0.1:53304]
+22:00:47.642 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:00:47.646 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:53304
+22:00:47.647 [nioEventLoopGroup-3-3] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 01f86e11, DeviceId: web_test_device
+22:00:47.647 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x01f86e11, L:/127.0.0.1:8091 - R:/127.0.0.1:53304] WebSocket version V13 server handshake
+22:00:47.647 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: /eAsJTSy3m8BHaw+oe+ltA==, response: LtKfnN0+Dr7UJd8ef+Cdhp9embQ=
+22:00:47.670 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x92c55d26, L:/127.0.0.1:8091 - R:/127.0.0.1:53305]
+22:00:47.670 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:00:47.672 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:53305
+22:00:47.673 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 92c55d26, DeviceId: web_test_device
+22:00:47.673 [nioEventLoopGroup-3-4] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x92c55d26, L:/127.0.0.1:8091 - R:/127.0.0.1:53305] WebSocket version V13 server handshake
+22:00:47.673 [nioEventLoopGroup-3-4] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: /tQTL8cUIPrEmbCVHkCcLA==, response: t9f/ZsFh2r+Dd1XXJE3rP7nQ32Y=
+22:00:47.678 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:00:47.680 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:00:47.680 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:00:47.682 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:00:47.683 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:00:47.683 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:00:47.689 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:00:47.693 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 92c55d26, DeviceId: web_test_device
+22:00:47.693 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:01:01.230 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 92c55d26, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:01:01.230 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+22:32:43.952 [nioEventLoopGroup-3-4] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 92c55d26, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+22:32:43.953 [DatebookHikariCP housekeeper] WARN  com.zaxxer.hikari.pool.HikariPool - DatebookHikariCP - Thread starvation or clock leap detected (housekeeper delta=30m34s853ms682µs).
+22:32:43.956 [nioEventLoopGroup-3-3] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 01f86e11
+22:32:43.956 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 48f03bbe
+22:32:43.965 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:32:43.966 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+22:32:43.968 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:32:43.973 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 92c55d26, DeviceId: web_test_device
+22:32:43.973 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:53305
+22:32:44.374 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+22:32:44.374 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+22:32:44.375 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xe8e5a6f6, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+22:32:44.375 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:53304
+22:32:44.376 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:53142
+22:32:44.377 [nioEventLoopGroup-3-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 6 thread-local buffer(s) from thread: nioEventLoopGroup-3-2
+22:32:44.391 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+22:32:44.437 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+22:32:50.606 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 12320 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+22:32:50.611 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+22:32:51.825 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+22:32:51.833 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+22:32:51.834 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+22:32:51.834 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+22:32:51.967 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+22:32:51.968 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1305 ms
+22:32:52.701 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+22:32:52.706 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+22:32:52.711 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+22:32:52.712 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+22:32:52.721 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+22:32:52.728 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+22:32:52.728 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+22:32:52.735 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+22:32:52.735 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+22:32:52.736 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+22:32:52.736 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+22:32:52.737 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+22:32:52.737 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+22:32:52.737 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+22:32:52.738 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+22:32:52.738 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+22:32:52.738 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+22:32:52.738 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+22:32:52.739 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+22:32:52.739 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+22:32:52.739 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+22:32:52.740 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+22:32:52.740 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+22:32:52.741 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+22:32:52.741 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+22:32:52.741 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+22:32:52.742 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+22:32:52.743 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+22:32:52.778 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 12320 (auto-detected)
+22:32:52.779 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+22:32:52.779 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+22:32:53.099 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+22:32:53.100 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+22:32:53.117 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+22:32:53.126 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+22:32:53.126 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+22:32:53.137 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+22:32:53.137 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+22:32:53.137 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+22:32:53.137 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+22:32:53.137 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+22:32:53.137 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+22:32:53.137 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+22:32:53.138 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+22:32:53.138 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+22:32:53.138 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+22:32:53.138 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+22:32:53.138 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+22:32:53.145 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+22:32:53.145 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+22:32:53.145 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+22:32:53.146 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+22:32:53.159 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8ced0488] REGISTERED
+22:32:53.160 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8ced0488] BIND: 0.0.0.0/0.0.0.0:8091
+22:32:53.161 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+22:32:53.162 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8ced0488, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+22:32:53.608 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+22:32:53.635 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+22:32:53.646 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+22:32:54.293 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+22:32:54.293 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+22:32:54.293 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+22:32:54.293 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+22:32:54.293 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+22:32:54.307 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.179 seconds (JVM running for 5.463)
+22:32:54.314 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+22:32:54.314 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+22:32:54.314 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+22:32:54.767 [RMI TCP Connection(1)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+22:32:54.767 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+22:32:54.768 [RMI TCP Connection(2)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+22:32:54.768 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+22:32:54.768 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+22:32:54.946 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+22:33:07.837 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8ced0488, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x11176353, L:/127.0.0.1:8091 - R:/127.0.0.1:55379]
+22:33:07.838 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8ced0488, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:33:07.847 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+22:33:07.847 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+22:33:07.848 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@3aed16ab
+22:33:07.876 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+22:33:07.876 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+22:33:07.879 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:55379
+22:33:07.882 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+22:33:07.883 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+22:33:07.883 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+22:33:07.883 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+22:33:07.883 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+22:33:07.902 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 11176353, DeviceId: web_test_device
+22:33:07.905 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x11176353, L:/127.0.0.1:8091 - R:/127.0.0.1:55379] WebSocket version V13 server handshake
+22:33:07.906 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: jpyiR6cOHT7anqGC+VffOA==, response: mT04I2vMhTPoBBUCIFSsyA6Oydk=
+22:33:07.937 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8ced0488, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xde584f39, L:/127.0.0.1:8091 - R:/127.0.0.1:55381]
+22:33:07.937 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8ced0488, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:33:07.941 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:55381
+22:33:07.942 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: de584f39, DeviceId: web_test_device
+22:33:07.942 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xde584f39, L:/127.0.0.1:8091 - R:/127.0.0.1:55381] WebSocket version V13 server handshake
+22:33:07.942 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: Imo1R3PHvjzUbc4VNXf0nA==, response: AV/OyNDpQJeezrBU+g0aH5T3Yic=
+22:33:07.947 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:33:07.985 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:33:08.001 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:33:08.013 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:33:08.022 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:33:08.022 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:33:08.024 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:33:08.028 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: de584f39, DeviceId: web_test_device
+22:33:08.028 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:33:08.034 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: de584f39, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:33:08.039 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+22:33:08.045 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: de584f39, DeviceId: web_test_device, 异常: refCnt: 0, decrement: 1
+io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
+	at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:83)
+	at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:148)
+	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:101)
+	at io.netty.buffer.DefaultByteBufHolder.release(DefaultByteBufHolder.java:111)
+	at io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:90)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:106)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+22:33:08.050 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:33:08.051 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+22:33:08.053 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:33:08.057 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: de584f39, DeviceId: web_test_device
+22:33:08.057 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:55381
+22:34:07.890 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:35:07.895 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:36:07.901 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:37:07.911 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:38:07.921 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:39:07.927 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:40:07.939 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:41:07.944 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:42:07.952 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:43:07.961 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:44:07.970 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:45:07.982 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:46:07.993 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:47:07.995 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:48:08.000 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:49:08.011 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:50:08.018 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:51:08.031 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:52:08.042 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:53:08.050 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:54:08.061 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:55:08.077 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:56:08.085 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 11176353
+22:56:20.127 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+22:56:20.130 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:55379
+22:56:20.130 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8ced0488, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+22:56:20.130 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x8ced0488, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+22:56:20.130 [nioEventLoopGroup-3-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 6 thread-local buffer(s) from thread: nioEventLoopGroup-3-2
+22:56:20.133 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+22:56:20.136 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+22:56:25.263 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 30284 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+22:56:25.265 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+22:56:26.411 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+22:56:26.418 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+22:56:26.419 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+22:56:26.419 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+22:56:26.549 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+22:56:26.549 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1234 ms
+22:56:27.256 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+22:56:27.262 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+22:56:27.266 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+22:56:27.267 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+22:56:27.276 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+22:56:27.282 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+22:56:27.282 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+22:56:27.288 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+22:56:27.289 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+22:56:27.289 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+22:56:27.290 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+22:56:27.290 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+22:56:27.291 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+22:56:27.291 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+22:56:27.292 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+22:56:27.292 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+22:56:27.292 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+22:56:27.293 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+22:56:27.293 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+22:56:27.293 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+22:56:27.293 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+22:56:27.294 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+22:56:27.294 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+22:56:27.295 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+22:56:27.295 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+22:56:27.295 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+22:56:27.295 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+22:56:27.297 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+22:56:27.331 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 30284 (auto-detected)
+22:56:27.333 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+22:56:27.333 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+22:56:27.673 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+22:56:27.674 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+22:56:27.691 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+22:56:27.699 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+22:56:27.700 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+22:56:27.713 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+22:56:27.722 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+22:56:27.722 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+22:56:27.724 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+22:56:27.726 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+22:56:27.738 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0] REGISTERED
+22:56:27.739 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0] BIND: 0.0.0.0/0.0.0.0:8091
+22:56:27.741 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+22:56:27.742 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+22:56:28.204 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+22:56:28.233 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+22:56:28.246 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+22:56:28.924 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+22:56:28.924 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+22:56:28.924 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+22:56:28.924 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+22:56:28.924 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+22:56:28.940 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.171 seconds (JVM running for 5.196)
+22:56:28.947 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+22:56:28.947 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+22:56:28.947 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+22:56:29.682 [RMI TCP Connection(1)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+22:56:29.682 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+22:56:29.683 [RMI TCP Connection(2)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+22:56:29.683 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+22:56:29.684 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+22:56:29.839 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+22:56:43.928 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x740ff551, L:/127.0.0.1:8091 - R:/127.0.0.1:56687]
+22:56:43.930 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:56:43.940 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+22:56:43.940 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+22:56:43.942 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@277f501b
+22:56:43.973 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+22:56:43.973 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+22:56:43.976 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:56687
+22:56:43.980 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+22:56:43.980 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+22:56:43.980 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+22:56:43.980 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+22:56:43.980 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+22:56:44.002 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 740ff551, DeviceId: web_test_device
+22:56:44.005 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x740ff551, L:/127.0.0.1:8091 - R:/127.0.0.1:56687] WebSocket version V13 server handshake
+22:56:44.006 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: zD3N9nmZAhzepkk1Jh8dRQ==, response: 0MfYS0S1xbWmVdAHZf2pCSccnCs=
+22:56:44.038 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xc9dd006e, L:/127.0.0.1:8091 - R:/127.0.0.1:56688]
+22:56:44.038 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:56:44.043 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:56688
+22:56:44.044 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: c9dd006e, DeviceId: web_test_device
+22:56:44.044 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xc9dd006e, L:/127.0.0.1:8091 - R:/127.0.0.1:56688] WebSocket version V13 server handshake
+22:56:44.044 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: njVWfa2XBbWNnpJmU+nT4w==, response: dpT0FYU+983X6JN2IStzzrbf9pU=
+22:56:44.049 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:56:44.090 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:56:44.110 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:56:44.122 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:56:44.131 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:56:44.131 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:56:44.137 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:56:44.143 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: c9dd006e, DeviceId: web_test_device
+22:56:44.143 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:56:44.150 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: c9dd006e, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:56:44.157 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+22:56:51.532 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:56:51.534 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:56:51.534 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:56:51.537 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:56:51.539 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:56:51.539 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:56:51.544 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:56:51.548 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: c9dd006e, DeviceId: web_test_device
+22:56:51.548 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"detect","text":"你好"}
+22:56:51.549 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: c9dd006e, State: detect, Mode: manual
+22:56:51.549 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 检测到唤醒词: 你好
+22:56:51.549 [nioEventLoopGroup-3-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: c9dd006e, Type: stt, State: start, Text: 你好
+22:56:51.554 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==>  Preparing: SELECT sys_config.configId, sys_config.userId, sys_config.configName, sys_config.configDesc, sys_config.configType, sys_config.provider, sys_config.appId, sys_config.apiKey, sys_config.apiSecret, sys_config.apiUrl, sys_config.isDefault, sys_config.state, sys_config.createTime FROM sys_config WHERE sys_config.configId = ?
+22:56:51.555 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==> Parameters: 1(Integer)
+22:56:51.557 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - <==      Total: 1
+22:56:52.102 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==>  Preparing: SELECT sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName, sys_role.ttsId, sys_role.userId, sys_role.state, sys_role.createTime FROM sys_role WHERE roleId = ?
+22:56:52.102 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==> Parameters: 3(Integer)
+22:56:52.104 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - <==      Total: 1
+22:56:52.153 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==>  Preparing: SELECT count(0) FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ?
+22:56:52.153 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==> Parameters: web_test_device(String)
+22:56:52.155 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - <==      Total: 1
+22:56:52.157 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==>  Preparing: SELECT sys_message.messageId, sys_message.message, sys_message.sender, sys_message.audioPath, sys_message.state, sys_message.createTime , sys_device.deviceId, sys_device.deviceName, sys_device.userId , sys_role.roleId, sys_role.roleName, sys_role.voiceName FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ? ORDER BY sys_message.createTime DESC LIMIT ?
+22:56:52.157 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==> Parameters: web_test_device(String), 10(Integer)
+22:56:52.161 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - <==      Total: 10
+22:56:52.162 [nioEventLoopGroup-3-2] INFO  c.x.w.llm.api.AbstractLlmService - 已初始化设备 web_test_device 的历史记录缓存，共 10 条消息
+22:56:52.163 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+22:56:52.164 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), c9dd006e(String), user(String), 3(Integer), 你好(String), null
+22:56:52.166 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+22:56:55.983 [pool-2-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: c9dd006e, Type: tts, State: start
+22:56:55.984 [pool-1-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: c9dd006e, Type: tts, State: sentence_start, Text: 你好！如果你需要帮助或者有任何问题，
+22:56:55.993 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:56:55.993 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+22:56:55.995 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:56:55.999 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: c9dd006e, DeviceId: web_test_device
+22:56:55.999 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:56688
+22:56:56.044 [pool-1-thread-1] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+22:56:57.360 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+22:56:57.360 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), c9dd006e(String), assistant(String), 3(Integer), 你好！如果你需要帮助或者有任何问题，我在这里为你服务。请告诉我你的需求。(String), audio/a158baa367084ff19f81223b0578fc33.mp3(String)
+22:56:57.362 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+22:57:14.137 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x0b421c86, L:/127.0.0.1:8091 - R:/127.0.0.1:56729]
+22:57:14.137 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:57:14.141 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:56729
+22:57:14.142 [nioEventLoopGroup-3-3] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 0b421c86, DeviceId: web_test_device
+22:57:14.143 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x0b421c86, L:/127.0.0.1:8091 - R:/127.0.0.1:56729] WebSocket version V13 server handshake
+22:57:14.143 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: O+/FtBDS1SKuhAp1fcRr1w==, response: tx7P8FK2izhrYqBl0ua1Hibj39I=
+22:57:14.161 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xe925bc74, L:/127.0.0.1:8091 - R:/127.0.0.1:56730]
+22:57:14.161 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:57:14.163 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:56730
+22:57:14.164 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: e925bc74, DeviceId: web_test_device
+22:57:14.164 [nioEventLoopGroup-3-4] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xe925bc74, L:/127.0.0.1:8091 - R:/127.0.0.1:56730] WebSocket version V13 server handshake
+22:57:14.165 [nioEventLoopGroup-3-4] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: 5FX5jNBcesURyFvWHvK5Eg==, response: 7/zBhlQpzhwBiptDAv+NxB853A8=
+22:57:14.169 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:14.170 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:57:14.171 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:57:14.173 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:57:14.175 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:57:14.175 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:57:14.179 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:57:14.183 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: e925bc74, DeviceId: web_test_device
+22:57:14.183 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:57:14.184 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: e925bc74, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:57:14.184 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+22:57:16.483 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:16.484 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:57:16.485 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:57:16.487 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:57:16.488 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:57:16.488 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:57:16.490 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:57:16.495 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: e925bc74, DeviceId: web_test_device
+22:57:16.495 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"start"}
+22:57:16.495 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: e925bc74, State: start, Mode: manual
+22:57:16.495 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 开始监听 - Mode: manual
+22:57:16.719 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:16.749 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:16.755 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:16.759 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:16.784 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:16.853 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:16.904 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:16.978 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.028 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.094 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.143 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.214 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.264 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.334 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.386 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.454 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.504 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.585 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.624 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.694 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.752 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.814 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.864 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.934 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:17.983 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.060 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.104 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.177 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.224 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.303 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.344 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.414 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.464 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.536 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.584 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.654 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.704 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.774 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.824 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.894 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:18.943 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.013 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.063 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.134 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.184 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.254 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.304 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.374 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.424 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.494 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.544 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.614 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.664 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.734 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.784 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.843 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.848 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:57:19.850 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:57:19.851 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:57:19.854 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:57:19.856 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:57:19.856 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:57:19.858 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:57:19.867 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: e925bc74, DeviceId: web_test_device
+22:57:19.867 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"stop"}
+22:57:19.867 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: e925bc74, State: stop, Mode: manual
+22:57:19.867 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 停止监听
+22:57:43.989 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 740ff551
+22:58:06.697 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+22:58:06.698 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+22:58:06.698 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:56729
+22:58:06.698 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x3a21dba0, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+22:58:06.698 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:56687
+22:58:06.699 [nioEventLoopGroup-3-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 11 thread-local buffer(s) from thread: nioEventLoopGroup-3-2
+22:58:06.700 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+22:58:06.701 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:58:06.701 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+22:58:06.710 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+22:58:11.710 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 17580 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+22:58:11.712 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+22:58:12.804 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+22:58:12.812 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+22:58:12.814 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+22:58:12.815 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+22:58:12.951 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+22:58:12.952 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1188 ms
+22:58:13.740 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+22:58:13.749 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+22:58:13.756 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+22:58:13.757 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+22:58:13.767 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+22:58:13.774 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+22:58:13.774 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+22:58:13.780 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+22:58:13.781 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+22:58:13.781 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+22:58:13.782 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+22:58:13.783 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+22:58:13.784 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+22:58:13.784 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+22:58:13.785 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+22:58:13.785 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+22:58:13.785 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+22:58:13.785 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+22:58:13.785 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+22:58:13.786 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+22:58:13.786 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+22:58:13.787 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+22:58:13.787 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+22:58:13.787 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+22:58:13.788 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+22:58:13.788 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+22:58:13.788 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+22:58:13.790 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+22:58:13.828 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 17580 (auto-detected)
+22:58:13.831 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+22:58:13.831 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+22:58:14.154 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+22:58:14.154 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+22:58:14.171 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+22:58:14.180 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+22:58:14.180 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+22:58:14.190 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+22:58:14.191 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+22:58:14.198 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+22:58:14.199 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+22:58:14.200 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+22:58:14.201 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+22:58:14.214 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4] REGISTERED
+22:58:14.215 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4] BIND: 0.0.0.0/0.0.0.0:8091
+22:58:14.216 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+22:58:14.217 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+22:58:14.639 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+22:58:14.666 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+22:58:14.677 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+22:58:15.305 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+22:58:15.305 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+22:58:15.306 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+22:58:15.306 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+22:58:15.306 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+22:58:15.319 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.107 seconds (JVM running for 5.139)
+22:58:15.325 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+22:58:15.325 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+22:58:15.325 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+22:58:16.070 [RMI TCP Connection(5)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+22:58:16.070 [RMI TCP Connection(5)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+22:58:16.070 [RMI TCP Connection(4)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+22:58:16.070 [RMI TCP Connection(4)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+22:58:16.071 [RMI TCP Connection(5)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+22:58:16.210 [RMI TCP Connection(4)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+22:58:22.327 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xfb6efd1f, L:/127.0.0.1:8091 - R:/127.0.0.1:56857]
+22:58:22.328 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:58:22.337 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+22:58:22.337 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+22:58:22.338 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@5542c0b8
+22:58:22.367 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+22:58:22.368 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+22:58:22.370 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:56857
+22:58:22.374 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+22:58:22.374 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+22:58:22.374 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+22:58:22.374 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+22:58:22.374 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+22:58:22.395 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: fb6efd1f, DeviceId: web_test_device
+22:58:22.397 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xfb6efd1f, L:/127.0.0.1:8091 - R:/127.0.0.1:56857] WebSocket version V13 server handshake
+22:58:22.398 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: R0Pgf2SW68TOOjDDHYxDIg==, response: IqmU7geksfWS7/h2dobmuHcO5Lc=
+22:58:22.421 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x2be81c93, L:/127.0.0.1:8091 - R:/127.0.0.1:56858]
+22:58:22.421 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:58:22.425 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:56858
+22:58:22.426 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 2be81c93, DeviceId: web_test_device
+22:58:22.426 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x2be81c93, L:/127.0.0.1:8091 - R:/127.0.0.1:56858] WebSocket version V13 server handshake
+22:58:22.426 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: RlIJgMtufx5sck3gLvbqpw==, response: RBdolhxxjckHxL2GIlKboo+CFLU=
+22:58:22.471 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:58:22.489 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:58:22.501 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:58:22.510 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:58:22.510 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:58:22.515 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:58:22.520 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 2be81c93, DeviceId: web_test_device
+22:58:22.521 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:58:22.527 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 2be81c93, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:58:22.533 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+22:58:26.181 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:58:26.182 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:58:26.185 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:58:26.186 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:58:26.187 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:58:26.188 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:58:26.195 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 2be81c93, DeviceId: web_test_device
+22:58:26.196 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"detect","text":"你好"}
+22:58:26.196 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 2be81c93, State: detect, Mode: manual
+22:58:26.196 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 检测到唤醒词: 你好
+22:58:26.196 [nioEventLoopGroup-3-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 2be81c93, Type: stt, State: start, Text: 你好
+22:58:26.203 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==>  Preparing: SELECT sys_config.configId, sys_config.userId, sys_config.configName, sys_config.configDesc, sys_config.configType, sys_config.provider, sys_config.appId, sys_config.apiKey, sys_config.apiSecret, sys_config.apiUrl, sys_config.isDefault, sys_config.state, sys_config.createTime FROM sys_config WHERE sys_config.configId = ?
+22:58:26.203 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==> Parameters: 1(Integer)
+22:58:26.205 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - <==      Total: 1
+22:58:26.729 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==>  Preparing: SELECT sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName, sys_role.ttsId, sys_role.userId, sys_role.state, sys_role.createTime FROM sys_role WHERE roleId = ?
+22:58:26.730 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==> Parameters: 3(Integer)
+22:58:26.731 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - <==      Total: 1
+22:58:26.774 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==>  Preparing: SELECT count(0) FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ?
+22:58:26.774 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==> Parameters: web_test_device(String)
+22:58:26.780 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - <==      Total: 1
+22:58:26.782 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==>  Preparing: SELECT sys_message.messageId, sys_message.message, sys_message.sender, sys_message.audioPath, sys_message.state, sys_message.createTime , sys_device.deviceId, sys_device.deviceName, sys_device.userId , sys_role.roleId, sys_role.roleName, sys_role.voiceName FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ? ORDER BY sys_message.createTime DESC LIMIT ?
+22:58:26.783 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==> Parameters: web_test_device(String), 10(Integer)
+22:58:26.787 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - <==      Total: 10
+22:58:26.788 [nioEventLoopGroup-3-2] INFO  c.x.w.llm.api.AbstractLlmService - 已初始化设备 web_test_device 的历史记录缓存，共 10 条消息
+22:58:26.789 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+22:58:26.790 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 2be81c93(String), user(String), 3(Integer), 你好(String), null
+22:58:26.791 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+22:58:30.101 [pool-2-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 2be81c93, Type: tts, State: start
+22:58:30.102 [pool-1-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 2be81c93, Type: tts, State: sentence_start, Text: 你好！有什么我可以帮你的吗？
+22:58:30.110 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:58:30.110 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+22:58:30.116 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:58:30.120 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 2be81c93, DeviceId: web_test_device
+22:58:30.120 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:56858
+22:58:30.171 [pool-1-thread-1] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+22:58:32.146 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+22:58:32.146 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 2be81c93(String), assistant(String), 3(Integer), 你好！有什么我可以帮你的吗？如果你有任何问题或需要信息，请随时告诉我。(String), audio/030494c934c646dca09e735ec1513b35.mp3(String)
+22:58:32.152 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+22:58:41.193 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0xf87f8c18, L:/127.0.0.1:8091 - R:/127.0.0.1:56879]
+22:58:41.193 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:58:41.197 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:56879
+22:58:41.197 [nioEventLoopGroup-3-3] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: f87f8c18, DeviceId: web_test_device
+22:58:41.197 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0xf87f8c18, L:/127.0.0.1:8091 - R:/127.0.0.1:56879] WebSocket version V13 server handshake
+22:58:41.198 [nioEventLoopGroup-3-3] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: LsoKHnnNZaXyKpJnMD0f+w==, response: +Q/RsRGpg5U5R0oI/lJbtysbTdQ=
+22:58:41.217 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x3892ef58, L:/127.0.0.1:8091 - R:/127.0.0.1:56880]
+22:58:41.217 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+22:58:41.219 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:56880
+22:58:41.220 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 3892ef58, DeviceId: web_test_device
+22:58:41.221 [nioEventLoopGroup-3-4] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x3892ef58, L:/127.0.0.1:8091 - R:/127.0.0.1:56880] WebSocket version V13 server handshake
+22:58:41.221 [nioEventLoopGroup-3-4] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: LXb6UqFZGfECZDte+MaevQ==, response: 7Tg3AgZaqaGdYxvHGiYVlqjUnIc=
+22:58:41.226 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:58:41.227 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:58:41.229 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:58:41.230 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:58:41.230 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:58:41.236 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:58:41.240 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 3892ef58, DeviceId: web_test_device
+22:58:41.240 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:58:41.240 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 3892ef58, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+22:58:41.240 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+22:58:42.767 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:58:42.768 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:58:42.770 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:58:42.772 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:58:42.773 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:58:42.778 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:58:42.782 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 3892ef58, DeviceId: web_test_device
+22:58:42.783 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"start"}
+22:58:42.783 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 3892ef58, State: start, Mode: manual
+22:58:42.783 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 开始监听 - Mode: manual
+22:58:42.836 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:42.895 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:42.955 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.015 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.074 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.136 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.194 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.254 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.316 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.378 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.434 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.495 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.554 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.615 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.675 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.735 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.794 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.854 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.915 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:43.974 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.035 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.095 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.154 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.214 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.275 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.336 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.394 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.454 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.514 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.575 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.635 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.694 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.754 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.815 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.874 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.935 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:44.994 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.054 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.114 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.174 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.235 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.297 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.354 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.422 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.475 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.534 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.594 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.654 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.714 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.774 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.847 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.894 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:45.955 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.014 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.077 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.135 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.200 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.254 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.320 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.374 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.434 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.495 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.555 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.621 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.680 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.735 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.799 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.855 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.920 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:46.974 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.035 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.095 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.155 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.215 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.279 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.335 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.394 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.454 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.515 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.574 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.638 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.699 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.754 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.813 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.875 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.935 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:47.995 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.057 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.114 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.174 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.243 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.294 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.354 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.415 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.474 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.534 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.594 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.660 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.718 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.774 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.835 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.895 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:48.954 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.014 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.074 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.137 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.195 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.254 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.315 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.374 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.441 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.494 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.555 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.615 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.674 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.734 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.796 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.854 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.921 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:49.975 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.034 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.094 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.154 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.214 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.274 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.335 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.398 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.460 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.517 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.575 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.642 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.694 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.760 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.814 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.874 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.934 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:50.995 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.056 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.114 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.174 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.234 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.294 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.356 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.421 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.474 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.535 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.598 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.654 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.719 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.774 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.843 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.896 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:51.955 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.016 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.074 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.134 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.194 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.254 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.314 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.375 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.434 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.494 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.555 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.615 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.675 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.734 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.794 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.854 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.914 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:52.975 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:53.036 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:53.094 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:53.155 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:53.215 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:58:53.225 [nioEventLoopGroup-3-4] INFO  c.x.w.h.BinaryWebSocketFrameHandler - 检测到语音结束 - SessionId: 3892ef58, 音频大小: 92892 字节
+22:58:54.321 [nioEventLoopGroup-3-4] DEBUG c.x.w.stt.providers.VoskSttService - D:\project\java\xiaozhi-esp32-server-java/models/vosk-model
+22:59:22.411 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: fb6efd1f
+22:59:28.323 [nioEventLoopGroup-3-4] INFO  c.x.w.stt.providers.VoskSttService - Vosk 模型加载成功！路径: D:\project\java\xiaozhi-esp32-server-java/models/vosk-model
+22:59:28.324 [nioEventLoopGroup-3-4] INFO  c.x.w.stt.providers.VoskSttService - Vosk STT服务初始化完成
+22:59:28.325 [nioEventLoopGroup-3-4] INFO  c.x.w.stt.factory.SttServiceFactory - Vosk STT服务初始化成功
+22:59:28.326 [nioEventLoopGroup-3-4] INFO  c.x.w.service.SpeechToTextService - 使用默认STT服务: vosk
+22:59:29.676 [nioEventLoopGroup-3-4] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 3892ef58, DeviceId: web_test_device, 异常: Could not initialize class org.bytedeco.ffmpeg.global.avutil
+java.lang.NoClassDefFoundError: Could not initialize class org.bytedeco.ffmpeg.global.avutil
+	at java.lang.Class.forName0(Native Method)
+	at java.lang.Class.forName(Class.java:348)
+	at org.bytedeco.javacpp.Loader.load(Loader.java:1289)
+	at org.bytedeco.javacpp.Loader.load(Loader.java:1234)
+	at org.bytedeco.javacpp.Loader.load(Loader.java:1210)
+	at org.bytedeco.ffmpeg.avformat.Write_packet_Pointer_BytePointer_int.<clinit>(Write_packet_Pointer_BytePointer_int.java:21)
+	at org.bytedeco.javacv.FFmpegFrameRecorder.<clinit>(FFmpegFrameRecorder.java:350)
+	at com.xiaozhi.utils.AudioUtils.saveAsMp3File(AudioUtils.java:36)
+	at com.xiaozhi.websocket.stt.providers.VoskSttService.recognition(VoskSttService.java:63)
+	at com.xiaozhi.websocket.service.SpeechToTextService.recognition(SpeechToTextService.java:71)
+	at com.xiaozhi.websocket.handler.BinaryWebSocketFrameHandler.processAudioData(BinaryWebSocketFrameHandler.java:103)
+	at com.xiaozhi.websocket.handler.BinaryWebSocketFrameHandler.channelRead0(BinaryWebSocketFrameHandler.java:80)
+	at com.xiaozhi.websocket.handler.BinaryWebSocketFrameHandler.channelRead0(BinaryWebSocketFrameHandler.java:27)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketControlFrameHandler.channelRead0(WebSocketControlFrameHandler.java:39)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:102)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+22:59:29.678 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:59:29.716 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:59:29.717 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:59:29.718 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:59:29.719 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:59:29.720 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:59:29.720 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:59:29.721 [nioEventLoopGroup-3-4] INFO  c.x.w.h.WebSocketControlFrameHandler - WebSocket 控制帧处理器
+22:59:29.725 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+22:59:29.726 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+22:59:29.731 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+22:59:29.734 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+22:59:29.735 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+22:59:29.736 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+22:59:29.742 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 3892ef58, DeviceId: web_test_device
+22:59:29.742 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"stop"}
+22:59:29.742 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 3892ef58, State: stop, Mode: manual
+22:59:29.743 [nioEventLoopGroup-3-4] INFO  c.x.w.h.TextWebSocketFrameHandler - 停止监听
+22:59:41.205 [nioEventLoopGroup-3-3] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: f87f8c18
+23:00:22.394 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: fb6efd1f
+23:00:29.751 [nioEventLoopGroup-3-4] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 3892ef58
+23:00:41.220 [nioEventLoopGroup-3-3] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: f87f8c18
+23:01:01.476 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+23:01:01.477 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:56857
+23:01:01.477 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+23:01:01.477 [nioEventLoopGroup-3-3] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:56879
+23:01:01.477 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x2cd094d4, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+23:01:01.479 [nioEventLoopGroup-3-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 12 thread-local buffer(s) from thread: nioEventLoopGroup-3-2
+23:01:01.480 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:01:01.480 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+23:01:01.480 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+23:01:01.487 [nioEventLoopGroup-3-4] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:01:01.507 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+23:01:08.778 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 28500 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+23:01:08.781 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+23:01:10.115 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+23:01:10.123 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+23:01:10.124 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+23:01:10.124 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+23:01:10.265 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+23:01:10.265 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1428 ms
+23:01:11.066 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+23:01:11.071 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+23:01:11.080 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+23:01:11.081 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+23:01:11.090 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+23:01:11.096 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+23:01:11.097 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+23:01:11.103 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+23:01:11.104 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+23:01:11.105 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+23:01:11.105 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+23:01:11.106 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+23:01:11.106 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+23:01:11.106 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+23:01:11.107 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+23:01:11.107 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+23:01:11.107 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+23:01:11.107 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+23:01:11.107 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+23:01:11.107 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+23:01:11.108 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+23:01:11.108 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+23:01:11.108 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+23:01:11.109 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+23:01:11.109 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+23:01:11.110 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+23:01:11.110 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+23:01:11.111 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+23:01:11.156 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 28500 (auto-detected)
+23:01:11.157 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+23:01:11.157 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+23:01:11.497 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+23:01:11.497 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+23:01:11.518 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+23:01:11.533 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+23:01:11.534 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+23:01:11.546 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+23:01:11.555 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+23:01:11.555 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+23:01:11.557 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+23:01:11.558 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+23:01:11.571 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x86fac8fb] REGISTERED
+23:01:11.572 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x86fac8fb] BIND: 0.0.0.0/0.0.0.0:8091
+23:01:11.574 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+23:01:11.575 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x86fac8fb, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+23:01:12.103 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+23:01:12.139 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+23:01:12.153 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+23:01:12.896 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:01:12.896 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+23:01:12.896 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+23:01:12.896 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+23:01:12.896 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:01:12.910 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.721 seconds (JVM running for 5.979)
+23:01:12.918 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+23:01:12.919 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+23:01:12.919 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+23:01:14.783 [RMI TCP Connection(4)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+23:01:14.783 [RMI TCP Connection(5)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+23:01:14.783 [RMI TCP Connection(4)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+23:01:14.783 [RMI TCP Connection(5)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+23:01:14.785 [RMI TCP Connection(5)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
+23:01:14.953 [RMI TCP Connection(4)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+23:07:13.151 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+23:07:13.154 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+23:07:13.154 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x86fac8fb, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+23:07:13.154 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x86fac8fb, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+23:07:13.160 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+23:10:18.163 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 18180 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+23:10:18.165 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+23:10:19.291 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+23:10:19.297 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+23:10:19.298 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+23:10:19.298 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+23:10:19.417 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+23:10:19.417 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1195 ms
+23:10:20.155 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+23:10:20.162 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+23:10:20.166 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+23:10:20.167 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+23:10:20.176 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+23:10:20.183 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+23:10:20.183 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+23:10:20.190 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+23:10:20.190 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+23:10:20.192 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+23:10:20.192 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+23:10:20.193 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+23:10:20.194 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+23:10:20.194 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+23:10:20.195 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+23:10:20.195 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+23:10:20.196 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+23:10:20.196 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+23:10:20.196 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+23:10:20.196 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+23:10:20.197 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+23:10:20.198 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+23:10:20.198 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+23:10:20.199 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+23:10:20.199 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+23:10:20.199 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+23:10:20.199 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+23:10:20.201 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+23:10:20.242 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 18180 (auto-detected)
+23:10:20.243 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+23:10:20.244 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+23:10:20.594 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+23:10:20.595 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+23:10:20.613 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+23:10:20.621 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+23:10:20.621 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+23:10:20.635 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+23:10:20.643 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+23:10:20.643 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+23:10:20.645 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+23:10:20.646 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+23:10:20.658 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x17c2c062] REGISTERED
+23:10:20.660 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x17c2c062] BIND: 0.0.0.0/0.0.0.0:8091
+23:10:20.661 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+23:10:20.662 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x17c2c062, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+23:10:21.109 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+23:10:21.135 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+23:10:21.146 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+23:10:21.780 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:10:21.780 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+23:10:21.780 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+23:10:21.780 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+23:10:21.780 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:10:21.793 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.034 seconds (JVM running for 6.088)
+23:10:21.799 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+23:10:21.799 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+23:10:21.799 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+23:10:22.849 [RMI TCP Connection(3)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+23:10:22.849 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+23:10:22.850 [RMI TCP Connection(2)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+23:10:22.850 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+23:10:22.851 [RMI TCP Connection(3)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+23:10:22.990 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+23:10:36.651 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x17c2c062, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x40999352, L:/127.0.0.1:8091 - R:/127.0.0.1:58187]
+23:10:36.652 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x17c2c062, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+23:10:36.668 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+23:10:36.668 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+23:10:36.669 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@70c0d468
+23:10:36.706 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+23:10:36.706 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+23:10:36.709 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:58187
+23:10:36.714 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+23:10:36.714 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+23:10:36.714 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+23:10:36.714 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+23:10:36.714 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+23:10:36.735 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 40999352, DeviceId: web_test_device
+23:10:36.737 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x40999352, L:/127.0.0.1:8091 - R:/127.0.0.1:58187] WebSocket version V13 server handshake
+23:10:36.738 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: zYlCXUdSB47xymz17qZ5jw==, response: 1zwAsDACkxhAYTD/cMyMZB/aza0=
+23:10:36.759 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x17c2c062, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x85b72eab, L:/127.0.0.1:8091 - R:/127.0.0.1:58188]
+23:10:36.760 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x17c2c062, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+23:10:36.764 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:58188
+23:10:36.765 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 85b72eab, DeviceId: web_test_device
+23:10:36.765 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x85b72eab, L:/127.0.0.1:8091 - R:/127.0.0.1:58188] WebSocket version V13 server handshake
+23:10:36.765 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: BEaYR7iOvDvOn6fqFwsLIw==, response: 3H6B5qaySKHdqKdlDDSwjYHQtFI=
+23:10:36.815 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:10:36.830 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:10:36.843 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:10:36.855 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:10:36.855 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:10:36.857 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:10:36.863 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 85b72eab, DeviceId: web_test_device
+23:10:36.863 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+23:10:36.874 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 85b72eab, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+23:10:36.879 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+23:10:39.596 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:10:39.597 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:10:39.599 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:10:39.600 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:10:39.601 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:10:39.603 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:10:39.607 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 85b72eab, DeviceId: web_test_device
+23:10:39.608 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"start"}
+23:10:39.608 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 85b72eab, State: start, Mode: manual
+23:10:39.608 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 开始监听 - Mode: manual
+23:10:42.849 [nioEventLoopGroup-3-2] INFO  c.x.w.h.BinaryWebSocketFrameHandler - 检测到语音结束 - SessionId: 85b72eab, 音频大小: 56460 字节
+23:10:43.867 [nioEventLoopGroup-3-2] DEBUG c.x.w.stt.providers.VoskSttService - D:\project\java\xiaozhi-esp32-server-java/models/vosk-model
+23:11:11.079 [nioEventLoopGroup-3-2] INFO  c.x.w.stt.providers.VoskSttService - Vosk 模型加载成功！路径: D:\project\java\xiaozhi-esp32-server-java/models/vosk-model
+23:11:11.087 [nioEventLoopGroup-3-2] INFO  c.x.w.stt.providers.VoskSttService - Vosk STT服务初始化完成
+23:11:11.088 [nioEventLoopGroup-3-2] INFO  c.x.w.stt.factory.SttServiceFactory - Vosk STT服务初始化成功
+23:11:11.088 [nioEventLoopGroup-3-2] INFO  c.x.w.service.SpeechToTextService - 使用默认STT服务: vosk
+23:11:11.977 [nioEventLoopGroup-3-2] ERROR c.x.w.h.WebSocketExceptionHandler - WebSocket处理异常 - SessionId: 85b72eab, DeviceId: web_test_device, 异常: no jniavutil in java.library.path
+java.lang.UnsatisfiedLinkError: no jniavutil in java.library.path
+	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1860)
+	at java.lang.Runtime.loadLibrary0(Runtime.java:871)
+	at java.lang.System.loadLibrary(System.java:1122)
+	at org.bytedeco.javacpp.Loader.loadLibrary(Loader.java:1832)
+	at org.bytedeco.javacpp.Loader.load(Loader.java:1423)
+	at org.bytedeco.javacpp.Loader.load(Loader.java:1234)
+	at org.bytedeco.javacpp.Loader.load(Loader.java:1210)
+	at org.bytedeco.ffmpeg.global.avutil.<clinit>(avutil.java:14)
+	at java.lang.Class.forName0(Native Method)
+	at java.lang.Class.forName(Class.java:348)
+	at org.bytedeco.javacpp.Loader.load(Loader.java:1289)
+	at org.bytedeco.javacpp.Loader.load(Loader.java:1234)
+	at org.bytedeco.javacpp.Loader.load(Loader.java:1226)
+	at com.xiaozhi.utils.AudioUtils.<clinit>(AudioUtils.java:23)
+	at com.xiaozhi.websocket.stt.providers.VoskSttService.recognition(VoskSttService.java:63)
+	at com.xiaozhi.websocket.service.SpeechToTextService.recognition(SpeechToTextService.java:71)
+	at com.xiaozhi.websocket.handler.BinaryWebSocketFrameHandler.processAudioData(BinaryWebSocketFrameHandler.java:103)
+	at com.xiaozhi.websocket.handler.BinaryWebSocketFrameHandler.channelRead0(BinaryWebSocketFrameHandler.java:80)
+	at com.xiaozhi.websocket.handler.BinaryWebSocketFrameHandler.channelRead0(BinaryWebSocketFrameHandler.java:27)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketControlFrameHandler.channelRead0(WebSocketControlFrameHandler.java:38)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:102)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
+	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at com.xiaozhi.websocket.handler.WebSocketHandshakeHandler.channelRead(WebSocketHandshakeHandler.java:57)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
+	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
+	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
+	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
+	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
+	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
+	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
+	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
+	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
+	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(Thread.java:750)
+Caused by: java.lang.UnsatisfiedLinkError: Could not find jniavutil in class, module, and library paths.
+	at org.bytedeco.javacpp.Loader.loadLibrary(Loader.java:1799)
+	... 63 common frames omitted
+23:11:12.036 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:11:12.037 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:11:12.038 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:11:12.040 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:11:12.040 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:11:12.042 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:11:12.050 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 85b72eab, DeviceId: web_test_device
+23:11:12.050 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"stop"}
+23:11:12.050 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 85b72eab, State: stop, Mode: manual
+23:11:12.050 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 停止监听
+23:12:20.407 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:12:20.408 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:12:20.411 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:12:20.414 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:12:20.414 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:12:20.415 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:12:20.419 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 85b72eab, DeviceId: web_test_device
+23:12:20.419 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"detect","text":"你好"}
+23:12:20.421 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 85b72eab, State: detect, Mode: manual
+23:12:20.421 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 检测到唤醒词: 你好
+23:12:20.421 [nioEventLoopGroup-3-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 85b72eab, Type: stt, State: start, Text: 你好
+23:12:20.424 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==>  Preparing: SELECT sys_config.configId, sys_config.userId, sys_config.configName, sys_config.configDesc, sys_config.configType, sys_config.provider, sys_config.appId, sys_config.apiKey, sys_config.apiSecret, sys_config.apiUrl, sys_config.isDefault, sys_config.state, sys_config.createTime FROM sys_config WHERE sys_config.configId = ?
+23:12:20.425 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==> Parameters: 1(Integer)
+23:12:20.429 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - <==      Total: 1
+23:12:21.012 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==>  Preparing: SELECT sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName, sys_role.ttsId, sys_role.userId, sys_role.state, sys_role.createTime FROM sys_role WHERE roleId = ?
+23:12:21.013 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==> Parameters: 3(Integer)
+23:12:21.014 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - <==      Total: 1
+23:12:21.065 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==>  Preparing: SELECT count(0) FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ?
+23:12:21.065 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==> Parameters: web_test_device(String)
+23:12:21.087 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - <==      Total: 1
+23:12:21.089 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==>  Preparing: SELECT sys_message.messageId, sys_message.message, sys_message.sender, sys_message.audioPath, sys_message.state, sys_message.createTime , sys_device.deviceId, sys_device.deviceName, sys_device.userId , sys_role.roleId, sys_role.roleName, sys_role.voiceName FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ? ORDER BY sys_message.createTime DESC LIMIT ?
+23:12:21.089 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==> Parameters: web_test_device(String), 10(Integer)
+23:12:21.101 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - <==      Total: 10
+23:12:21.102 [nioEventLoopGroup-3-2] INFO  c.x.w.llm.api.AbstractLlmService - 已初始化设备 web_test_device 的历史记录缓存，共 10 条消息
+23:12:21.103 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+23:12:21.104 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 85b72eab(String), user(String), 3(Integer), 你好(String), null
+23:12:21.112 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+23:12:25.765 [pool-2-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 85b72eab, Type: tts, State: start
+23:12:25.766 [pool-1-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 85b72eab, Type: tts, State: sentence_start, Text: 你好！如果你有任何问题或需要帮助，
+23:12:25.774 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:12:25.774 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+23:12:25.777 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:12:25.782 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 85b72eab, DeviceId: web_test_device
+23:12:25.782 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:58188
+23:12:25.827 [pool-1-thread-1] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+23:12:27.703 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+23:12:27.704 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 85b72eab(String), assistant(String), 3(Integer), 你好！如果你有任何问题或需要帮助，请随时告诉我，我会尽力为你提供帮助。(String), audio/5b6ba6e7b1a04fe6a24c3b42d6154025.mp3(String)
+23:12:27.706 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+23:15:36.721 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 40999352
+23:17:19.869 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+23:17:19.869 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x17c2c062, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+23:17:19.869 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:58187
+23:17:19.870 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0x17c2c062, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+23:17:19.871 [nioEventLoopGroup-3-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 21 thread-local buffer(s) from thread: nioEventLoopGroup-3-2
+23:17:19.873 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+23:17:19.878 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+23:17:32.018 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 24840 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+23:17:32.021 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+23:17:33.166 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+23:17:33.174 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+23:17:33.175 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+23:17:33.176 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+23:17:33.305 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+23:17:33.306 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1234 ms
+23:17:34.039 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+23:17:34.044 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+23:17:34.049 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+23:17:34.050 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+23:17:34.058 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+23:17:34.065 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+23:17:34.065 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+23:17:34.071 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+23:17:34.071 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+23:17:34.072 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+23:17:34.072 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+23:17:34.073 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+23:17:34.073 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+23:17:34.073 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+23:17:34.074 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+23:17:34.074 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+23:17:34.075 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+23:17:34.075 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+23:17:34.075 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+23:17:34.075 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+23:17:34.075 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+23:17:34.076 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+23:17:34.076 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+23:17:34.077 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+23:17:34.077 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+23:17:34.077 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+23:17:34.078 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+23:17:34.079 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+23:17:34.114 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 24840 (auto-detected)
+23:17:34.116 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+23:17:34.116 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+23:17:34.437 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+23:17:34.439 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+23:17:34.457 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+23:17:34.467 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+23:17:34.467 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+23:17:34.479 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+23:17:34.479 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+23:17:34.479 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+23:17:34.479 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+23:17:34.480 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+23:17:34.480 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+23:17:34.480 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+23:17:34.480 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+23:17:34.480 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+23:17:34.480 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+23:17:34.480 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+23:17:34.480 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+23:17:34.488 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+23:17:34.488 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+23:17:34.488 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+23:17:34.489 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+23:17:34.502 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xf4952643] REGISTERED
+23:17:34.504 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xf4952643] BIND: 0.0.0.0/0.0.0.0:8091
+23:17:34.505 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+23:17:34.506 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xf4952643, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+23:17:34.941 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+23:17:34.967 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+23:17:34.977 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+23:17:35.617 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:17:35.617 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+23:17:35.617 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+23:17:35.617 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+23:17:35.617 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:17:35.630 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.09 seconds (JVM running for 5.799)
+23:17:35.637 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+23:17:35.637 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+23:17:35.637 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+23:17:36.095 [RMI TCP Connection(1)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+23:17:36.095 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+23:17:36.096 [RMI TCP Connection(2)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+23:17:36.096 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+23:17:36.097 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
+23:17:36.289 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+23:17:43.750 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xf4952643, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x3f9eb9b0, L:/127.0.0.1:8091 - R:/127.0.0.1:59034]
+23:17:43.751 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xf4952643, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+23:17:43.761 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+23:17:43.761 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+23:17:43.762 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@1af0dcde
+23:17:43.792 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+23:17:43.793 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+23:17:43.796 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:59034
+23:17:43.800 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+23:17:43.800 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+23:17:43.800 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+23:17:43.800 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+23:17:43.800 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+23:17:43.821 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 3f9eb9b0, DeviceId: web_test_device
+23:17:43.824 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x3f9eb9b0, L:/127.0.0.1:8091 - R:/127.0.0.1:59034] WebSocket version V13 server handshake
+23:17:43.826 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: W132RqJT3ZV1Y/RmlnOqiw==, response: e7ADMUEf+C2/LkZfqgk+WOrV4e8=
+23:17:43.855 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xf4952643, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x34b1b4b3, L:/127.0.0.1:8091 - R:/127.0.0.1:59035]
+23:17:43.856 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xf4952643, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+23:17:43.859 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:59035
+23:17:43.860 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 34b1b4b3, DeviceId: web_test_device
+23:17:43.860 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x34b1b4b3, L:/127.0.0.1:8091 - R:/127.0.0.1:59035] WebSocket version V13 server handshake
+23:17:43.860 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: cuZ5P7bWhPRPwDzN7/JMPw==, response: ZgS2BoP2Uk06ta2X4jKUd7uEz0M=
+23:17:43.908 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:17:43.925 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:17:43.943 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:17:43.952 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:17:43.952 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:17:43.956 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:17:43.960 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 34b1b4b3, DeviceId: web_test_device
+23:17:43.960 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+23:17:43.968 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 34b1b4b3, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+23:17:43.973 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+23:17:47.847 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:17:47.847 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:17:47.849 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:17:47.851 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:17:47.851 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:17:47.852 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:17:47.857 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 34b1b4b3, DeviceId: web_test_device
+23:17:47.857 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"start"}
+23:17:47.857 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 34b1b4b3, State: start, Mode: manual
+23:17:47.857 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 开始监听 - Mode: manual
+23:17:50.683 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:17:50.684 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:17:50.686 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:17:50.687 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:17:50.687 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:17:50.692 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:17:50.696 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 34b1b4b3, DeviceId: web_test_device
+23:17:50.696 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"stop"}
+23:17:50.696 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 34b1b4b3, State: stop, Mode: manual
+23:17:50.696 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 停止监听
+23:18:51.208 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+23:18:51.210 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xf4952643, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+23:18:51.210 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:59034
+23:18:51.211 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xf4952643, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+23:18:51.212 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+23:18:51.212 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:18:51.213 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+23:18:51.223 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+23:18:55.365 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 30208 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+23:18:55.370 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+23:18:56.888 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+23:18:56.895 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+23:18:56.897 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+23:18:56.897 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+23:18:57.029 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+23:18:57.029 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1538 ms
+23:18:57.726 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+23:18:57.730 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+23:18:57.735 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+23:18:57.736 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+23:18:57.744 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+23:18:57.751 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+23:18:57.751 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+23:18:57.757 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+23:18:57.758 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+23:18:57.758 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+23:18:57.759 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+23:18:57.759 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+23:18:57.759 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+23:18:57.760 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+23:18:57.760 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+23:18:57.760 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+23:18:57.760 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+23:18:57.760 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+23:18:57.761 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+23:18:57.761 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+23:18:57.761 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+23:18:57.762 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+23:18:57.762 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+23:18:57.762 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+23:18:57.763 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+23:18:57.763 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+23:18:57.763 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+23:18:57.765 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+23:18:57.803 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 30208 (auto-detected)
+23:18:57.805 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+23:18:57.805 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+23:18:58.134 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+23:18:58.135 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+23:18:58.152 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+23:18:58.161 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+23:18:58.161 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+23:18:58.173 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+23:18:58.181 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+23:18:58.181 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+23:18:58.181 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+23:18:58.182 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+23:18:58.196 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc1a083c6] REGISTERED
+23:18:58.197 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc1a083c6] BIND: 0.0.0.0/0.0.0.0:8091
+23:18:58.199 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+23:18:58.199 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc1a083c6, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+23:18:58.648 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+23:18:58.675 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+23:18:58.686 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+23:18:59.341 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:18:59.341 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+23:18:59.341 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+23:18:59.341 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+23:18:59.341 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:18:59.353 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.865 seconds (JVM running for 6.051)
+23:18:59.358 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+23:18:59.358 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+23:18:59.358 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+23:18:59.915 [RMI TCP Connection(1)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+23:18:59.915 [RMI TCP Connection(2)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+23:18:59.916 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+23:18:59.916 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+23:18:59.917 [RMI TCP Connection(1)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+23:19:00.078 [RMI TCP Connection(2)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+23:19:09.814 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+23:19:09.816 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc1a083c6, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+23:19:09.816 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc1a083c6, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+23:19:09.818 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+23:19:09.827 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+23:19:20.617 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 9800 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+23:19:20.620 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+23:19:22.100 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+23:19:22.106 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+23:19:22.108 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+23:19:22.108 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+23:19:22.259 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+23:19:22.259 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1558 ms
+23:19:22.995 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+23:19:23.000 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+23:19:23.005 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+23:19:23.005 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+23:19:23.014 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+23:19:23.020 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+23:19:23.021 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+23:19:23.027 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+23:19:23.027 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+23:19:23.028 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+23:19:23.029 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+23:19:23.029 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+23:19:23.030 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+23:19:23.030 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+23:19:23.031 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+23:19:23.031 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+23:19:23.031 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+23:19:23.031 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+23:19:23.031 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+23:19:23.031 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+23:19:23.032 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+23:19:23.032 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+23:19:23.033 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+23:19:23.033 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+23:19:23.033 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+23:19:23.034 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+23:19:23.034 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+23:19:23.036 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+23:19:23.071 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 9800 (auto-detected)
+23:19:23.072 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+23:19:23.072 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+23:19:23.397 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+23:19:23.398 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+23:19:23.415 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+23:19:23.424 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+23:19:23.424 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+23:19:23.435 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+23:19:23.435 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+23:19:23.435 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+23:19:23.435 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+23:19:23.436 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+23:19:23.436 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+23:19:23.436 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+23:19:23.436 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+23:19:23.436 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+23:19:23.436 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+23:19:23.436 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+23:19:23.436 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+23:19:23.442 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+23:19:23.443 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+23:19:23.444 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+23:19:23.446 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+23:19:23.458 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xcc2ea282] REGISTERED
+23:19:23.459 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xcc2ea282] BIND: 0.0.0.0/0.0.0.0:8091
+23:19:23.461 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+23:19:23.461 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xcc2ea282, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+23:19:23.929 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+23:19:23.956 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+23:19:23.967 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+23:19:24.604 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:19:24.604 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+23:19:24.604 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+23:19:24.604 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+23:19:24.604 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:19:24.617 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.728 seconds (JVM running for 6.08)
+23:19:24.621 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+23:19:24.622 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+23:19:24.622 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+23:19:25.294 [RMI TCP Connection(6)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+23:19:25.295 [RMI TCP Connection(5)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+23:19:25.295 [RMI TCP Connection(6)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+23:19:25.295 [RMI TCP Connection(5)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+23:19:25.296 [RMI TCP Connection(6)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+23:19:25.449 [RMI TCP Connection(5)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+23:19:30.112 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xcc2ea282, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x4736b530, L:/127.0.0.1:8091 - R:/127.0.0.1:59181]
+23:19:30.114 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xcc2ea282, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+23:19:30.123 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+23:19:30.123 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+23:19:30.125 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@2a8567df
+23:19:30.153 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+23:19:30.153 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+23:19:30.157 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:59181
+23:19:30.160 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+23:19:30.160 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+23:19:30.160 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+23:19:30.160 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+23:19:30.160 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+23:19:30.181 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 4736b530, DeviceId: web_test_device
+23:19:30.183 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x4736b530, L:/127.0.0.1:8091 - R:/127.0.0.1:59181] WebSocket version V13 server handshake
+23:19:30.184 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: GMPunOZ1R80RQhjSPE7FYg==, response: s8Yzsfi8CQhj25ycgodAZwCzfkA=
+23:19:30.210 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xcc2ea282, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x2f4773da, L:/127.0.0.1:8091 - R:/127.0.0.1:59182]
+23:19:30.210 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xcc2ea282, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+23:19:30.214 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:59182
+23:19:30.215 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 2f4773da, DeviceId: web_test_device
+23:19:30.215 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x2f4773da, L:/127.0.0.1:8091 - R:/127.0.0.1:59182] WebSocket version V13 server handshake
+23:19:30.216 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: LPdAElAYaoKyB7O+17/PRA==, response: PgpHY6sTelh/UwMYFPdbLf9+4mY=
+23:19:30.259 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:19:30.277 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:19:30.300 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:19:30.309 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:19:30.309 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:19:30.313 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:19:30.318 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 2f4773da, DeviceId: web_test_device
+23:19:30.318 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+23:19:30.327 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 2f4773da, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+23:19:30.332 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+23:19:33.111 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:19:33.112 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:19:33.115 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:19:33.117 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:19:33.117 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:19:33.122 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:19:33.126 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 2f4773da, DeviceId: web_test_device
+23:19:33.126 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"start"}
+23:19:33.126 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 2f4773da, State: start, Mode: manual
+23:19:33.126 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 开始监听 - Mode: manual
+23:19:36.074 [nioEventLoopGroup-3-2] INFO  c.x.w.h.BinaryWebSocketFrameHandler - 检测到语音结束 - SessionId: 2f4773da, 音频大小: 55380 字节
+23:19:36.622 [nioEventLoopGroup-3-2] DEBUG c.x.w.stt.providers.VoskSttService - D:\project\java\xiaozhi-esp32-server-java/models/vosk-model
+23:20:02.511 [nioEventLoopGroup-3-2] INFO  c.x.w.stt.providers.VoskSttService - Vosk 模型加载成功！路径: D:\project\java\xiaozhi-esp32-server-java/models/vosk-model
+23:20:02.511 [nioEventLoopGroup-3-2] INFO  c.x.w.stt.providers.VoskSttService - Vosk STT服务初始化完成
+23:20:02.511 [nioEventLoopGroup-3-2] INFO  c.x.w.stt.factory.SttServiceFactory - Vosk STT服务初始化成功
+23:20:02.511 [nioEventLoopGroup-3-2] INFO  c.x.w.service.SpeechToTextService - 使用默认STT服务: vosk
+23:20:04.243 [nioEventLoopGroup-3-2] INFO  c.x.w.service.SpeechToTextService - 语音识别完成，耗时：1.732 秒
+23:20:04.246 [nioEventLoopGroup-3-2] INFO  c.x.w.h.BinaryWebSocketFrameHandler - 语音识别结果 - SessionId: 2f4773da, 内容: 早上 好 啊
+23:20:04.246 [nioEventLoopGroup-3-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 2f4773da, Type: stt, State: start, Text: 早上 好 啊
+23:20:04.251 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==>  Preparing: SELECT sys_config.configId, sys_config.userId, sys_config.configName, sys_config.configDesc, sys_config.configType, sys_config.provider, sys_config.appId, sys_config.apiKey, sys_config.apiSecret, sys_config.apiUrl, sys_config.isDefault, sys_config.state, sys_config.createTime FROM sys_config WHERE sys_config.configId = ?
+23:20:04.252 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==> Parameters: 1(Integer)
+23:20:04.254 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - <==      Total: 1
+23:20:04.851 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==>  Preparing: SELECT sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName, sys_role.ttsId, sys_role.userId, sys_role.state, sys_role.createTime FROM sys_role WHERE roleId = ?
+23:20:04.851 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==> Parameters: 3(Integer)
+23:20:04.852 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - <==      Total: 1
+23:20:04.905 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==>  Preparing: SELECT count(0) FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ?
+23:20:04.906 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==> Parameters: web_test_device(String)
+23:20:04.914 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - <==      Total: 1
+23:20:04.916 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==>  Preparing: SELECT sys_message.messageId, sys_message.message, sys_message.sender, sys_message.audioPath, sys_message.state, sys_message.createTime , sys_device.deviceId, sys_device.deviceName, sys_device.userId , sys_role.roleId, sys_role.roleName, sys_role.voiceName FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ? ORDER BY sys_message.createTime DESC LIMIT ?
+23:20:04.916 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==> Parameters: web_test_device(String), 10(Integer)
+23:20:04.922 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - <==      Total: 10
+23:20:04.923 [nioEventLoopGroup-3-2] INFO  c.x.w.llm.api.AbstractLlmService - 已初始化设备 web_test_device 的历史记录缓存，共 10 条消息
+23:20:04.923 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+23:20:04.925 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 2f4773da(String), user(String), 3(Integer), 早上 好 啊(String), null
+23:20:04.927 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+23:20:04.963 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:20:04.963 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:20:04.966 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:20:05.080 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:20:05.081 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:20:05.086 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:20:05.090 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 2f4773da, DeviceId: web_test_device
+23:20:05.090 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"stop"}
+23:20:05.090 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 2f4773da, State: stop, Mode: manual
+23:20:05.090 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 停止监听
+23:20:08.165 [pool-2-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 2f4773da, Type: tts, State: start
+23:20:08.166 [pool-1-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 2f4773da, Type: tts, State: sentence_start, Text: 早上好！新的一天开始了，
+23:20:08.175 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:20:08.176 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+23:20:08.178 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:20:08.182 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 2f4773da, DeviceId: web_test_device
+23:20:08.182 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:59182
+23:20:08.242 [pool-1-thread-1] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+23:20:08.596 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+23:20:08.597 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 2f4773da(String), assistant(String), 3(Integer), 早上好！新的一天开始了，有什么我可以帮你的吗？(String), audio/52f70cad7ec0446f85d55466cec432dc.mp3(String)
+23:20:08.598 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+23:24:30.168 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 4736b530
+23:29:30.171 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 4736b530
+23:34:06.302 [SpringApplicationShutdownHook] INFO  c.x.w.config.NettyWebSocketConfig - 关闭Netty WebSocket服务器
+23:34:06.303 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xcc2ea282, L:/0:0:0:0:0:0:0:0:8091] INACTIVE
+23:34:06.303 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:59181
+23:34:06.303 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xcc2ea282, L:/0:0:0:0:0:0:0:0:8091] UNREGISTERED
+23:34:06.304 [nioEventLoopGroup-3-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 20 thread-local buffer(s) from thread: nioEventLoopGroup-3-2
+23:34:06.306 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown initiated...
+23:34:06.311 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Shutdown completed.
+23:35:15.297 [main] INFO  com.xiaozhi.XiaozhiApplication - Starting XiaozhiApplication using Java 1.8.0_321 on pc-yuchen with PID 22396 (D:\project\java\xiaozhi-esp32-server-java\target\classes started by yc in D:\project\java\xiaozhi-esp32-server-java)
+23:35:15.301 [main] INFO  com.xiaozhi.XiaozhiApplication - The following 1 profile is active: "dev"
+23:35:16.408 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port(s): 8092 (http)
+23:35:16.416 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8092"]
+23:35:16.417 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+23:35:16.417 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.83]
+23:35:16.549 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+23:35:16.549 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1195 ms
+23:35:17.246 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声抑制处理器已初始化
+23:35:17.251 [main] INFO  c.x.w.config.NettyWebSocketConfig - 启动Netty WebSocket服务器，端口：8091，路径：/ws/xiaozhi/v1/
+23:35:17.255 [main] DEBUG i.n.u.i.l.InternalLoggerFactory - Using SLF4J as the default logging framework
+23:35:17.256 [main] DEBUG i.n.c.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 16
+23:35:17.266 [main] DEBUG i.n.u.concurrent.GlobalEventExecutor - -Dio.netty.globalEventExecutor.quietPeriodSeconds: 1
+23:35:17.273 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
+23:35:17.273 [main] DEBUG i.n.u.i.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
+23:35:17.280 [main] DEBUG i.n.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
+23:35:17.280 [main] DEBUG i.n.util.internal.PlatformDependent0 - Java version: 8
+23:35:17.281 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
+23:35:17.282 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
+23:35:17.282 [main] DEBUG i.n.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
+23:35:17.282 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
+23:35:17.283 [main] DEBUG i.n.util.internal.PlatformDependent0 - direct buffer constructor: available
+23:35:17.283 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
+23:35:17.283 [main] DEBUG i.n.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
+23:35:17.284 [main] DEBUG i.n.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, {int,long}): available
+23:35:17.284 [main] DEBUG i.n.util.internal.PlatformDependent - sun.misc.Unsafe: available
+23:35:17.284 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.tmpdir: C:\Users\37010\AppData\Local\Temp (java.io.tmpdir)
+23:35:17.284 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
+23:35:17.284 [main] DEBUG i.n.util.internal.PlatformDependent - Platform: Windows
+23:35:17.286 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 3780640768 bytes
+23:35:17.286 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
+23:35:17.287 [main] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
+23:35:17.287 [main] DEBUG i.n.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
+23:35:17.287 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
+23:35:17.288 [main] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
+23:35:17.289 [main] DEBUG i.n.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
+23:35:17.329 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 22396 (auto-detected)
+23:35:17.331 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
+23:35:17.331 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
+23:35:17.673 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (Software Loopback Interface 1, 127.0.0.1)
+23:35:17.674 [main] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file \proc\sys\net\core\somaxconn. Default: 200
+23:35:17.691 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:00:25:ff:fe:84:8a:b4 (auto-detected)
+23:35:17.700 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
+23:35:17.701 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
+23:35:17.711 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 16
+23:35:17.711 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 16
+23:35:17.711 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
+23:35:17.711 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 9
+23:35:17.711 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 4194304
+23:35:17.712 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
+23:35:17.712 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
+23:35:17.712 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
+23:35:17.712 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
+23:35:17.712 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
+23:35:17.712 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
+23:35:17.712 [main] DEBUG i.n.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
+23:35:17.719 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
+23:35:17.719 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
+23:35:17.721 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
+23:35:17.722 [main] DEBUG i.n.b.ChannelInitializerExtensions - -Dio.netty.bootstrap.extensions: null
+23:35:17.734 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc41705a7] REGISTERED
+23:35:17.735 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc41705a7] BIND: 0.0.0.0/0.0.0.0:8091
+23:35:17.737 [main] INFO  c.x.w.config.NettyWebSocketConfig - Netty WebSocket服务器启动成功，监听端口: 8091
+23:35:17.737 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc41705a7, L:/0:0:0:0:0:0:0:0:8091] ACTIVE
+23:35:18.166 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint(s) beneath base path '/actuator'
+23:35:18.193 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8092"]
+23:35:18.203 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port(s): 8092 (http) with context path ''
+23:35:18.846 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:35:18.846 [main] INFO  com.xiaozhi.XiaozhiApplication - Spring Boot服务运行于: http://192.168.8.9:8092
+23:35:18.846 [main] INFO  com.xiaozhi.XiaozhiApplication - WebSocket服务运行于:
+23:35:18.846 [main] INFO  com.xiaozhi.XiaozhiApplication - ws://192.168.8.9:8091/ws/xiaozhi/v1/
+23:35:18.846 [main] INFO  com.xiaozhi.XiaozhiApplication - ==========================================================
+23:35:18.859 [main] INFO  com.xiaozhi.XiaozhiApplication - Started XiaozhiApplication in 4.292 seconds (JVM running for 5.617)
+23:35:18.867 [main] INFO  c.x.w.a.d.impl.SileroVadDetector - 噪声抑制功能已启用
+23:35:18.867 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 频谱减法因子已更新为: 1.5
+23:35:18.867 [main] INFO  c.x.w.a.processor.TarsosNoiseReducer - 噪声估计窗口已更新为: 15 帧
+23:35:19.473 [RMI TCP Connection(2)-192.168.8.9] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+23:35:19.474 [RMI TCP Connection(2)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+23:35:19.474 [RMI TCP Connection(1)-192.168.8.9] WARN  com.zaxxer.hikari.HikariConfig - DatebookHikariCP - idleTimeout is close to or more than maxLifetime, disabling it.
+23:35:19.475 [RMI TCP Connection(1)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Starting...
+23:35:19.475 [RMI TCP Connection(2)-192.168.8.9] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 1 ms
+23:35:19.623 [RMI TCP Connection(1)-192.168.8.9] INFO  com.zaxxer.hikari.HikariDataSource - DatebookHikariCP - Start completed.
+23:35:35.625 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc41705a7, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x32438bf4, L:/127.0.0.1:8091 - R:/127.0.0.1:60204]
+23:35:35.626 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc41705a7, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+23:35:35.636 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
+23:35:35.636 [nioEventLoopGroup-3-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
+23:35:35.637 [nioEventLoopGroup-3-1] DEBUG i.n.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@19cb5b25
+23:35:35.665 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibDecoder: false
+23:35:35.665 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.compression.ZlibCodecFactory - -Dio.netty.noJdkZlibEncoder: false
+23:35:35.669 [nioEventLoopGroup-3-1] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:60204
+23:35:35.672 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 4096
+23:35:35.672 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
+23:35:35.672 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: 32
+23:35:35.672 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: false
+23:35:35.672 [nioEventLoopGroup-3-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.batchFastThreadLocalOnly: true
+23:35:35.692 [nioEventLoopGroup-3-1] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 32438bf4, DeviceId: web_test_device
+23:35:35.695 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x32438bf4, L:/127.0.0.1:8091 - R:/127.0.0.1:60204] WebSocket version V13 server handshake
+23:35:35.696 [nioEventLoopGroup-3-1] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: Q3cvv5ALdaI5Aio62xmFtw==, response: ZuGalWkJ0twkvFv+D9Ol/LrT+Fw=
+23:35:35.727 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc41705a7, L:/0:0:0:0:0:0:0:0:8091] READ: [id: 0x8b72b1ab, L:/127.0.0.1:8091 - R:/127.0.0.1:60205]
+23:35:35.728 [nioEventLoopGroup-2-1] INFO  i.n.handler.logging.LoggingHandler - [id: 0xc41705a7, L:/0:0:0:0:0:0:0:0:8091] READ COMPLETE
+23:35:35.732 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端连接: /127.0.0.1:60205
+23:35:35.733 [nioEventLoopGroup-3-2] INFO  c.x.w.h.WebSocketHandshakeHandler - WebSocket握手请求 - SessionId: 8b72b1ab, DeviceId: web_test_device
+23:35:35.734 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - [id: 0x8b72b1ab, L:/127.0.0.1:8091 - R:/127.0.0.1:60205] WebSocket version V13 server handshake
+23:35:35.734 [nioEventLoopGroup-3-2] DEBUG i.n.h.c.h.w.WebSocketServerHandshaker - WebSocket version 13 server handshake key: QMVUF2JOf9emUWh1MjW97A==, response: 9XwJ/HoRASRdHdYzSyJiH1r+0+Y=
+23:35:35.779 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:35:35.798 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:35:35.819 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:35:35.827 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:35:35.828 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:35:35.831 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:35:35.837 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 8b72b1ab, DeviceId: web_test_device
+23:35:35.837 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+23:35:35.845 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到hello消息 - SessionId: 8b72b1ab, JsonNode={"type":"hello","device_id":"web_test_device","device_name":"Web测试设备","device_mac":"00:11:22:33:44:55","token":"your-token1"}
+23:35:35.850 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端音频参数 - 格式: , 采样率: 0, 声道: 0, 帧时长: 0ms
+23:35:39.165 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:35:39.166 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:35:39.170 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:35:39.172 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:35:39.172 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:35:39.173 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:35:39.181 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 8b72b1ab, DeviceId: web_test_device
+23:35:39.181 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"start"}
+23:35:39.182 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 8b72b1ab, State: start, Mode: manual
+23:35:39.182 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 开始监听 - Mode: manual
+23:35:42.830 [nioEventLoopGroup-3-2] INFO  c.x.w.h.BinaryWebSocketFrameHandler - 检测到语音结束 - SessionId: 8b72b1ab, 音频大小: 66576 字节
+23:35:43.845 [nioEventLoopGroup-3-2] DEBUG c.x.w.stt.providers.VoskSttService - D:\project\java\xiaozhi-esp32-server-java/models/vosk-model
+23:36:09.493 [nioEventLoopGroup-3-2] INFO  c.x.w.stt.providers.VoskSttService - Vosk 模型加载成功！路径: D:\project\java\xiaozhi-esp32-server-java/models/vosk-model
+23:36:09.493 [nioEventLoopGroup-3-2] INFO  c.x.w.stt.providers.VoskSttService - Vosk STT服务初始化完成
+23:36:09.493 [nioEventLoopGroup-3-2] INFO  c.x.w.stt.factory.SttServiceFactory - Vosk STT服务初始化成功
+23:36:09.493 [nioEventLoopGroup-3-2] INFO  c.x.w.service.SpeechToTextService - 使用默认STT服务: vosk
+23:36:11.397 [nioEventLoopGroup-3-2] INFO  c.x.w.service.SpeechToTextService - 语音识别完成，耗时：1.903 秒
+23:36:11.399 [nioEventLoopGroup-3-2] INFO  c.x.w.h.BinaryWebSocketFrameHandler - 语音识别结果 - SessionId: 8b72b1ab, 内容: 你好 早上 好 啊
+23:36:11.399 [nioEventLoopGroup-3-2] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 8b72b1ab, Type: stt, State: start, Text: 你好 早上 好 啊
+23:36:11.407 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==>  Preparing: SELECT sys_config.configId, sys_config.userId, sys_config.configName, sys_config.configDesc, sys_config.configType, sys_config.provider, sys_config.appId, sys_config.apiKey, sys_config.apiSecret, sys_config.apiUrl, sys_config.isDefault, sys_config.state, sys_config.createTime FROM sys_config WHERE sys_config.configId = ?
+23:36:11.407 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - ==> Parameters: 1(Integer)
+23:36:11.409 [nioEventLoopGroup-3-2] DEBUG c.x.d.ConfigMapper.selectConfigById - <==      Total: 1
+23:36:11.966 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==>  Preparing: SELECT sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName, sys_role.ttsId, sys_role.userId, sys_role.state, sys_role.createTime FROM sys_role WHERE roleId = ?
+23:36:11.967 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - ==> Parameters: 3(Integer)
+23:36:11.968 [nioEventLoopGroup-3-2] DEBUG c.x.dao.RoleMapper.selectRoleById - <==      Total: 1
+23:36:12.018 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==>  Preparing: SELECT count(0) FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ?
+23:36:12.019 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - ==> Parameters: web_test_device(String)
+23:36:12.022 [nioEventLoopGroup-3-2] DEBUG c.x.dao.MessageMapper.query_COUNT - <==      Total: 1
+23:36:12.024 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==>  Preparing: SELECT sys_message.messageId, sys_message.message, sys_message.sender, sys_message.audioPath, sys_message.state, sys_message.createTime , sys_device.deviceId, sys_device.deviceName, sys_device.userId , sys_role.roleId, sys_role.roleName, sys_role.voiceName FROM sys_message LEFT JOIN sys_device ON sys_message.deviceId = sys_device.deviceId LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId WHERE sys_message.state = 1 AND sys_message.deviceId = ? ORDER BY sys_message.createTime DESC LIMIT ?
+23:36:12.025 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - ==> Parameters: web_test_device(String), 10(Integer)
+23:36:12.030 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.query - <==      Total: 10
+23:36:12.030 [nioEventLoopGroup-3-2] INFO  c.x.w.llm.api.AbstractLlmService - 已初始化设备 web_test_device 的历史记录缓存，共 10 条消息
+23:36:12.031 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+23:36:12.032 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 8b72b1ab(String), user(String), 3(Integer), 你好 早上 好 啊(String), null
+23:36:12.034 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+23:36:12.070 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==>  Preparing: SELECT sys_device.deviceId, sys_device.deviceName, sys_device.ip, sys_device.wifiName, sys_device.chipModelName, sys_device.version, sys_device.state, sys_device.userId, sys_device.lastLogin, sys_device.createTime , sys_role.roleId, sys_role.roleName, sys_role.roleDesc, sys_role.voiceName , model_config.configId AS modelId , stt_config.configId AS sttId , tts_config.configId AS ttsId FROM sys_device LEFT JOIN sys_role ON sys_device.roleId = sys_role.roleId LEFT JOIN sys_config model_config ON sys_device.modelId = model_config.configId AND model_config.configType = 'llm' LEFT JOIN sys_config stt_config ON sys_device.sttId = stt_config.configId AND stt_config.configType = 'stt' LEFT JOIN sys_config tts_config ON ttsId = tts_config.configId AND tts_config.configType = 'tts' WHERE 1 = 1 AND deviceId = ?
+23:36:12.173 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - ==> Parameters: web_test_device(String)
+23:36:12.177 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.query - <==      Total: 1
+23:36:12.178 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:36:12.178 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 1(String), web_test_device(String)
+23:36:12.180 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:36:12.185 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接初始化 - SessionId: 8b72b1ab, DeviceId: web_test_device
+23:36:12.185 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端发送消息：msg={"type":"listen","mode":"manual","state":"stop"}
+23:36:12.185 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 收到listen消息 - SessionId: 8b72b1ab, State: stop, Mode: manual
+23:36:12.185 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 停止监听
+23:36:15.430 [pool-2-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 8b72b1ab, Type: tts, State: start
+23:36:15.431 [pool-1-thread-1] INFO  c.x.websocket.service.MessageService - 发送消息 - SessionId: 8b72b1ab, Type: tts, State: sentence_start, Text: 早上好！很高兴与您交流，
+23:36:15.439 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==>  Preparing: UPDATE sys_device SET state = ?, lastLogin = NOW() WHERE deviceId = ?
+23:36:15.440 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - ==> Parameters: 0(String), web_test_device(String)
+23:36:15.443 [nioEventLoopGroup-3-2] DEBUG com.xiaozhi.dao.DeviceMapper.update - <==    Updates: 1
+23:36:15.447 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - WebSocket连接关闭 - SessionId: 8b72b1ab, DeviceId: web_test_device
+23:36:15.447 [nioEventLoopGroup-3-2] INFO  c.x.w.h.TextWebSocketFrameHandler - 客户端断开连接: /127.0.0.1:60205
+23:36:15.494 [pool-1-thread-1] INFO  c.x.websocket.service.AudioService - 会话已关闭，停止发送音频
+23:36:15.857 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==>  Preparing: INSERT INTO sys_message ( deviceId, sessionId, sender, roleId, message, audioPath ) SELECT ?, ?, ?, ?, ?, ?
+23:36:15.857 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - ==> Parameters: web_test_device(String), 8b72b1ab(String), assistant(String), 3(Integer), 早上好！很高兴与您交流，有什么我可以为您服务的吗？(String), audio/a4d97a11bbc1439a90d4fe1700f18d2b.mp3(String)
+23:36:15.860 [OkHttp https://open.bigmodel.cn/...] DEBUG com.xiaozhi.dao.MessageMapper.add - <==    Updates: 1
+23:40:35.681 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 32438bf4
+23:45:35.681 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 32438bf4
+23:50:35.684 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 32438bf4
+23:55:35.698 [nioEventLoopGroup-3-1] DEBUG c.x.w.h.WebSocketHeartbeatHandler - 读空闲超时 - SessionId: 32438bf4

--- a/web/config/index.js
+++ b/web/config/index.js
@@ -11,14 +11,14 @@ module.exports = {
     assetsPublicPath: "/",
     proxyTable: {
       "/api": {
-        target: "http://localhost:8082",
+        target: "http://localhost:8081",
         changeOrigin: true,
         pathRewrite: {
           "^/api": "/api"
         }
       },
       "/system": {
-        target: "http://localhost:8092",
+        target: "http://localhost:8081",
         changeOrigin: true,
         pathRewrite: {
           "^/system": "/system"

--- a/web/src/views/page/Role.vue
+++ b/web/src/views/page/Role.vue
@@ -976,7 +976,7 @@ export default {
           voiceName: values.voiceName,
           provider: this.selectedProvider,
           message: this.testText,
-          ttsId: this.selectedttsId // 始终传递TTS配置ID
+          ttsId: this.selectedProvider === 'edge' ? -1 : this.selectedttsId
         };
 
         axios

--- a/web/src/views/page/Role.vue
+++ b/web/src/views/page/Role.vue
@@ -810,7 +810,8 @@ export default {
               url,
               data: {
                 roleId: this.editingRoleId,
-                ...formData
+                ...formData,
+                ttsId: formData.provider === 'edge' ? -1 : formData.ttsId
               }
             })
             .then(res => {


### PR DESCRIPTION
1.更改端口：springboot-port: 8081 , netty-port: 8082 , 方便与websocket本地同时启动对比测试

2.增加springboot自定义线程池

3.优化llm流程：能异步的地方，使用线程池异步处理

4.优化设备初始化和首次获取验证码逻辑：（1）绑定后不进入获取验证码逻辑（2）首次同一个设备每次获取相同验证码

5.适配Python的web测试界面：（1）websocket协议升级参数调整 （2）注释不重要的消息校验

6.优化音频帧发送逻辑：（1）使用LockSupport.parkNanos(delayNs)；精确控制  （2）增加延迟跳帧补偿

7.netty改造：（1）注意session_id获取，需从channel().attr()中获取  （2）发送客户端的音频帧使用BinaryWebSocketFrame，而不能直接发送ByteBuf